### PR TITLE
feat: allow the props to prevent creating new objects

### DIFF
--- a/src/components/Modals/AddCylinderModal.tsx
+++ b/src/components/Modals/AddCylinderModal.tsx
@@ -75,7 +75,7 @@ const AddCylinderModal = () => {
 										Add the new cylinders information to save it for next time.
 									</DialogTitle>
 
-									<ClientPicker />
+									<ClientPicker disableAdd={true} />
 
 									<TextInput
 										autoFocus

--- a/src/components/UI/FormElements/ClientPicker.tsx
+++ b/src/components/UI/FormElements/ClientPicker.tsx
@@ -33,7 +33,11 @@ function useLoadClients() {
 	return { clients, status, error }
 }
 
-const ClientPicker = () => {
+type ClientPickerProps = {
+	disableAdd?: boolean
+}
+
+const ClientPicker = ({ disableAdd }: ClientPickerProps) => {
 	const dispatch = useAppDispatch()
 	const { clients, status, error } = useLoadClients()
 
@@ -84,6 +88,7 @@ const ClientPicker = () => {
 				>
 					<Button
 						onClick={() => dispatch(updateAddClientModalOpen(true))}
+						hidden={disableAdd}
 						className='cursor-pointer px-3 py-2 text-gray-900 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden'
 					>
 						Add new Client
@@ -91,6 +96,8 @@ const ClientPicker = () => {
 					{query.length > 0 && (
 						<ComboboxOption
 							value={{ id: null, name: query }}
+							hidden={disableAdd}
+							disabled={true}
 							className='cursor-pointer px-3 py-2 text-gray-900 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden'
 						>
 							{query}

--- a/src/components/UI/FormElements/CylinderPicker.tsx
+++ b/src/components/UI/FormElements/CylinderPicker.tsx
@@ -18,9 +18,16 @@ import { updateCylinder } from '@/redux/fills/fillsSlice'
 import { useQuery } from '@tanstack/react-query'
 import { getAllCylinders } from '@/app/_api'
 
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
+dayjs.extend(duration)
+
 type CylinderPickerProps = {
 	isFill?: boolean
 	index?: number
+	disableAdd?: boolean
+	showExpired?: boolean
 }
 
 function useLoadCylinder() {
@@ -39,7 +46,12 @@ function useLoadCylinder() {
 	return { cylinders, status, error }
 }
 
-const CylinderPicker = ({ isFill, index }: CylinderPickerProps) => {
+const CylinderPicker = ({
+	isFill,
+	index,
+	disableAdd,
+	showExpired = false,
+}: CylinderPickerProps) => {
 	const { cylinders } = useLoadCylinder()
 	const dispatch = useAppDispatch()
 
@@ -100,6 +112,7 @@ const CylinderPicker = ({ isFill, index }: CylinderPickerProps) => {
 				>
 					<Button
 						onClick={() => dispatch(updateAddCylinderModalOpen(true))}
+						hidden={disableAdd}
 						className='cursor-pointer px-3 py-2 text-gray-900 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden'
 					>
 						Add new Cylinder
@@ -107,6 +120,8 @@ const CylinderPicker = ({ isFill, index }: CylinderPickerProps) => {
 					{query.length > 0 && (
 						<ComboboxOption
 							value={{ id: null, name: query }}
+							hidden={disableAdd}
+							disabled={true}
 							className='cursor-pointer px-3 py-2 text-gray-900 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden'
 						>
 							{query}
@@ -116,6 +131,10 @@ const CylinderPicker = ({ isFill, index }: CylinderPickerProps) => {
 						<ComboboxOption
 							key={cylinder.serialNumber}
 							value={cylinder}
+							disabled={
+								!showExpired &&
+								dayjs.duration(dayjs().diff(cylinder.lastHydro)).asYears() > 5
+							}
 							className='cursor-pointer px-3 py-2 text-gray-900 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden'
 						>
 							{cylinder.serialNumber}

--- a/src/redux/cylinder/cylinderSlice.ts
+++ b/src/redux/cylinder/cylinderSlice.ts
@@ -3,10 +3,10 @@ import dayjs from 'dayjs'
 
 export type Cylinder = {
 	serialNumber: string
-	birthDate: dayjs.Dayjs | null
-	lastHydro: dayjs.Dayjs | null
+	birthDate: dayjs.Dayjs
+	lastHydro: dayjs.Dayjs
 	lastVis: {
-		date: string
+		date: dayjs.Dayjs
 		passed: boolean
 		oxygenClean: boolean
 		details: string


### PR DESCRIPTION
sometimes we dont want to allow creating new objects when selecting one (ie should not be able to create a new client when selecting the owner of a new cylinder)