### PR TITLE
various small screen improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .next
+next-env.d.ts
 
 .eslintcache
 .env

--- a/docs/superpowers/plans/2026-05-18-table-filters.md
+++ b/docs/superpowers/plans/2026-05-18-table-filters.md
@@ -1,0 +1,844 @@
+# Table Filters & Sort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add filtering and combined sort to the cylinder and fill history tabs on `/history` using a shared toolbar component and filter hook, with filter state owned by per-tab wrapper components.
+
+**Architecture:** Each tab on the history page becomes its own component (`CylindersTab`, `FillsTab`) that owns filter and sort `useState`, builds predicate functions, runs the items through a shared `useTableFilters` hook, and renders a shared `<TableToolbar>` above the existing table. State is in-memory only; the underlying table components stay unchanged in their public API.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS v4, Headless UI ListBox, dayjs. No test framework — verification is `npm run lint`, `npm run build`, and the existing dev server.
+
+**Verification note:** This codebase has no unit test framework configured (per `CLAUDE.md`). Each task ends with `npm run lint` and (where types are touched) `npm run build`, then a manual browser check, then a commit.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/lib/fills.ts` — mix categorization helpers shared by row and filter
+- `src/hooks/useTableFilters.ts` — generic filter+sort hook
+- `src/components/UI/TableToolbar.tsx` — shared toolbar with filter slot, sort slot, chip row, clear-all
+- `src/components/History/CylindersTab.tsx` — wires cylinder filters/sort + toolbar
+- `src/components/History/FillsTab.tsx` — wires fill filters/sort + toolbar
+
+**Modify:**
+- `src/app/constants/FormConstants.ts` — add filter/sort option lists
+- `src/components/UI/FormElements/ListBox.tsx` — add optional controlled-mode `value` prop
+- `src/components/History/components/FillHistoryRow.tsx` — import mix helper from new lib
+- `src/app/history/page.tsx` — render the two new tab components
+
+---
+
+## Task 1: Extract fill mix helpers
+
+**Files:**
+- Create: `src/lib/fills.ts`
+- Modify: `src/components/History/components/FillHistoryRow.tsx`
+
+- [ ] **Step 1: Create `src/lib/fills.ts`**
+
+```ts
+export type FillMixCategory = 'air' | 'nitrox' | 'trimix'
+
+type MixSource = { oxygen: number; helium: number }
+
+export function getFillCategory(fill: MixSource): FillMixCategory {
+	if (fill.helium > 0) return 'trimix'
+	if (fill.oxygen === 20.9) return 'air'
+	return 'nitrox'
+}
+
+export function getFillMix(fill: MixSource): string {
+	if (fill.helium !== 0) return `${fill.oxygen}/${fill.helium}`
+	if (fill.oxygen === 20.9) return 'air'
+	return `EAN ${fill.oxygen}`
+}
+```
+
+- [ ] **Step 2: Update `FillHistoryRow.tsx` to import `getFillMix` from `@/lib/fills` and delete the local copy**
+
+Replace the local `getFillMix` function in `src/components/History/components/FillHistoryRow.tsx` with an import:
+
+```ts
+import { getFillMix } from '@/lib/fills'
+```
+
+Remove the local `function getFillMix(fill: FillHistory): string { ... }` block.
+
+- [ ] **Step 3: Verify lint + build**
+
+Run: `npm run lint`
+Expected: 0 errors (existing warnings unchanged).
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual check**
+
+Open `/history?tab=FILLS` in dev. Fill rows should still show the mix label correctly (air / EAN xx / x/y).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/fills.ts src/components/History/components/FillHistoryRow.tsx
+git commit -m "refactor: extract fill mix helpers into src/lib/fills"
+```
+
+---
+
+## Task 2: Add filter/sort option constants
+
+**Files:**
+- Modify: `src/app/constants/FormConstants.ts`
+
+- [ ] **Step 1: Append the new option lists**
+
+Add the following at the end of `src/app/constants/FormConstants.ts`. Use the `{ name, value }` shape that `ListBox` expects (see existing `ROLE_OPTIONS`).
+
+```ts
+export const YES_NO_ANY_OPTIONS = [
+	{ name: 'Any', value: 'any' },
+	{ name: 'Yes', value: 'yes' },
+	{ name: 'No', value: 'no' },
+]
+
+export const MIX_TYPE_OPTIONS = [
+	{ name: 'Any mix', value: 'any' },
+	{ name: 'Air', value: 'air' },
+	{ name: 'Nitrox', value: 'nitrox' },
+	{ name: 'Trimix', value: 'trimix' },
+]
+
+export const CYLINDER_SORT_OPTIONS = [
+	{ name: 'Serial (A→Z)', value: 'serial-asc' },
+	{ name: 'Last vis (oldest first)', value: 'lastVis-asc' },
+	{ name: 'Last vis (newest first)', value: 'lastVis-desc' },
+	{ name: 'Last hydro (oldest first)', value: 'lastHydro-asc' },
+	{ name: 'Last hydro (newest first)', value: 'lastHydro-desc' },
+]
+
+export const FILL_SORT_OPTIONS = [
+	{ name: 'Date (newest first)', value: 'date-desc' },
+	{ name: 'Date (oldest first)', value: 'date-asc' },
+	{ name: 'Mix type (A→Z)', value: 'mix-asc' },
+]
+```
+
+- [ ] **Step 2: Verify lint**
+
+Run: `npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/constants/FormConstants.ts
+git commit -m "feat: add filter and sort option constants for history tables"
+```
+
+---
+
+## Task 3: Add controlled-mode support to `ListBox` and `CylinderPicker`
+
+Both components currently manage their own selection state via `useState`. The toolbar's "Clear all" button needs to reset filters from the outside. `ClientPicker` already supports a `value`/`onChange` controlled pair (see `src/components/UI/FormElements/ClientPicker.tsx`) — bring `ListBox` and `CylinderPicker` to the same shape.
+
+**Files:**
+- Modify: `src/components/UI/FormElements/ListBox.tsx`
+- Modify: `src/components/UI/FormElements/CylinderPicker.tsx`
+
+- [ ] **Step 1: Add `value` to `ListBox`**
+
+Edit `src/components/UI/FormElements/ListBox.tsx`. Replace the `ListBoxProps` type and the start of the component body with:
+
+```tsx
+type ListBoxProps = {
+	items: Item[]
+	title: string
+	id: string
+	name: string
+	defaultValue?: Item
+	value?: Item
+	onChange?: (item: Item) => void
+}
+
+const ListBox = ({
+	items,
+	title,
+	id,
+	name,
+	defaultValue,
+	value,
+	onChange,
+}: ListBoxProps) => {
+	const [internal, setInternal] = useState<Item | undefined>(
+		defaultValue || items[0],
+	)
+	const isControlled = value !== undefined
+	const selected = isControlled ? value : internal
+
+	const handleChange = (item: Item) => {
+		if (!isControlled) setInternal(item)
+		onChange?.(item)
+	}
+
+	return (
+		<Listbox value={selected} onChange={handleChange}>
+			{/* keep the existing JSX below this point unchanged */}
+```
+
+Keep everything from `<Label …>` onwards exactly as it was — only the props type and the state/selected derivation change.
+
+- [ ] **Step 2: Add `value` to `CylinderPicker`**
+
+Edit `src/components/UI/FormElements/CylinderPicker.tsx`. Update the props type and the state derivation:
+
+```tsx
+type CylinderPickerProps = {
+	isFill?: boolean
+	index?: number
+	disableAdd?: boolean
+	showExpired?: boolean
+	initialValue?: Cylinder
+	value?: Cylinder | null
+	filter?: (c: Cylinder) => boolean
+	onChange?: (c?: Cylinder) => void
+	visPage?: boolean
+}
+
+const CylinderPicker = ({
+	isFill,
+	index,
+	disableAdd,
+	showExpired = false,
+	filter,
+	initialValue,
+	value,
+	onChange,
+	visPage,
+}: CylinderPickerProps) => {
+	// ...existing state/setup above...
+	const isControlled = value !== undefined
+	const currentValue = isControlled ? value : selectedCylinder
+```
+
+Then in the rest of the component, replace every read of `selectedCylinder` with `currentValue`, and inside the existing Combobox `onChange` handler, only call `setSelectedCylinder` when `!isControlled`. The handler should still call `onChange?.(c)` in both modes so the parent always sees changes. Do NOT change the Redux-dispatch effect — it should keep watching the internal `selectedCylinder` because the controlled mode used by the new filter UI does not pass `isFill`.
+
+- [ ] **Step 3: Verify lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: succeeds with 0 errors.
+
+- [ ] **Step 4: Manual check**
+
+Open any page that uses these components in uncontrolled mode:
+- `/settings` — role `ListBox` per user (uncontrolled `defaultValue`)
+- `/fills` — `CylinderPicker` in the fill rows (uncontrolled `initialValue` + Redux dispatch)
+
+Both must continue to behave exactly as before — the change is backwards compatible because `value` is optional and the controlled branch only activates when callers opt in.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/UI/FormElements/ListBox.tsx src/components/UI/FormElements/CylinderPicker.tsx
+git commit -m "feat: support controlled value prop on ListBox and CylinderPicker"
+```
+
+---
+
+## Task 4: Create `useTableFilters` hook
+
+**Files:**
+- Create: `src/hooks/useTableFilters.ts`
+
+- [ ] **Step 1: Write the hook**
+
+```ts
+'use client'
+
+import { useMemo } from 'react'
+
+type UseTableFiltersOptions<T> = {
+	predicates?: Array<(item: T) => boolean>
+	sort?: (a: T, b: T) => number
+}
+
+const useTableFilters = <T,>(
+	items: T[],
+	{ predicates, sort }: UseTableFiltersOptions<T> = {},
+): T[] => {
+	return useMemo(() => {
+		let result = items
+		if (predicates && predicates.length > 0) {
+			result = result.filter((item) => predicates.every((p) => p(item)))
+		}
+		if (sort) {
+			result = [...result].sort(sort)
+		}
+		return result
+	}, [items, predicates, sort])
+}
+
+export default useTableFilters
+```
+
+- [ ] **Step 2: Verify lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useTableFilters.ts
+git commit -m "feat: add useTableFilters hook"
+```
+
+---
+
+## Task 5: Create `<TableToolbar>` component
+
+The toolbar renders a horizontal row of filter controls passed as `filters`, a sort control passed as `sort`, an optional chip row below for active filters, and a "Clear all" button. The chips and clear button are hidden when no filters are active.
+
+**Files:**
+- Create: `src/components/UI/TableToolbar.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+'use client'
+
+import { ReactNode } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import Button from './Button'
+
+export type FilterChip = {
+	label: string
+	onClear: () => void
+}
+
+type TableToolbarProps = {
+	filters: ReactNode
+	sort?: ReactNode
+	chips?: FilterChip[]
+	onClearAll?: () => void
+}
+
+const TableToolbar = ({
+	filters,
+	sort,
+	chips = [],
+	onClearAll,
+}: TableToolbarProps) => {
+	const hasChips = chips.length > 0
+	return (
+		<div className='border-border bg-surface mb-4 rounded-lg border p-3'>
+			<div className='flex flex-wrap items-end gap-3'>
+				<div className='flex flex-1 flex-wrap items-end gap-3'>{filters}</div>
+				{sort && <div className='w-full sm:w-auto'>{sort}</div>}
+			</div>
+			{hasChips && (
+				<div className='mt-3 flex flex-wrap items-center gap-2'>
+					{chips.map((chip) => (
+						<button
+							key={chip.label}
+							type='button'
+							onClick={chip.onClear}
+							className='bg-card-hover text-text hover:bg-hover inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium'
+						>
+							<span>{chip.label}</span>
+							<XMarkIcon className='h-3.5 w-3.5' aria-hidden='true' />
+						</button>
+					))}
+					{onClearAll && (
+						<Button variant='ghost' onClick={onClearAll}>
+							Clear all
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default TableToolbar
+```
+
+- [ ] **Step 2: Verify lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/UI/TableToolbar.tsx
+git commit -m "feat: add TableToolbar component for filter + sort controls"
+```
+
+---
+
+## Task 6: Build `CylindersTab` with filters and sort
+
+This component owns cylinder filter and sort state, computes predicates and a comparator, runs the items through `useTableFilters`, and renders `<TableToolbar>` above `<CylinderListTable>`.
+
+**Files:**
+- Create: `src/components/History/CylindersTab.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+'use client'
+
+import { useMemo, useState } from 'react'
+import dayjs from 'dayjs'
+import { Cylinder } from '@/types/cylinder'
+import { Client } from '@/types/client'
+import CylinderListTable from '@/components/Cylinders/CylinderListTable'
+import TableToolbar, { FilterChip } from '@/components/UI/TableToolbar'
+import ListBox from '@/components/UI/FormElements/ListBox'
+import ClientPicker from '@/components/UI/FormElements/ClientPicker'
+import useTableFilters from '@/hooks/useTableFilters'
+import {
+	CYLINDER_SORT_OPTIONS,
+	YES_NO_ANY_OPTIONS,
+} from '@/app/constants/FormConstants'
+
+type CylindersTabProps = {
+	cylinders: Cylinder[]
+}
+
+type TriState = 'any' | 'yes' | 'no'
+
+const matchTri = (state: TriState, actual: boolean): boolean => {
+	if (state === 'any') return true
+	return state === 'yes' ? actual : !actual
+}
+
+const sortByValue: Record<string, (a: Cylinder, b: Cylinder) => number> = {
+	'serial-asc': (a, b) =>
+		(a.nickname ?? a.serialNumber).localeCompare(
+			b.nickname ?? b.serialNumber,
+		),
+	'lastVis-asc': (a, b) =>
+		dayjs(a.lastVis).valueOf() - dayjs(b.lastVis).valueOf(),
+	'lastVis-desc': (a, b) =>
+		dayjs(b.lastVis).valueOf() - dayjs(a.lastVis).valueOf(),
+	'lastHydro-asc': (a, b) =>
+		dayjs(a.lastHydro).valueOf() - dayjs(b.lastHydro).valueOf(),
+	'lastHydro-desc': (a, b) =>
+		dayjs(b.lastHydro).valueOf() - dayjs(a.lastHydro).valueOf(),
+}
+
+const triItem = (state: TriState) =>
+	YES_NO_ANY_OPTIONS.find((o) => o.value === state) ?? YES_NO_ANY_OPTIONS[0]
+
+const CylindersTab = ({ cylinders }: CylindersTabProps) => {
+	const [oxygen, setOxygen] = useState<TriState>('any')
+	const [needsVis, setNeedsVis] = useState<TriState>('any')
+	const [outOfHydro, setOutOfHydro] = useState<TriState>('any')
+	const [owner, setOwner] = useState<Client | null>(null)
+	const [sortValue, setSortValue] = useState<string>('serial-asc')
+
+	const predicates = useMemo(() => {
+		const now = dayjs()
+		const list: Array<(c: Cylinder) => boolean> = []
+		if (oxygen !== 'any') {
+			list.push((c) => matchTri(oxygen, c.oxygenClean))
+		}
+		if (needsVis !== 'any') {
+			list.push((c) =>
+				matchTri(needsVis, dayjs(c.lastVis).add(1, 'year').isBefore(now)),
+			)
+		}
+		if (outOfHydro !== 'any') {
+			list.push((c) =>
+				matchTri(outOfHydro, dayjs(c.lastHydro).add(5, 'year').isBefore(now)),
+			)
+		}
+		if (owner) {
+			list.push((c) => c.ownerId === owner.id)
+		}
+		return list
+	}, [oxygen, needsVis, outOfHydro, owner])
+
+	const sort = sortByValue[sortValue]
+	const filtered = useTableFilters(cylinders, { predicates, sort })
+
+	const chips: FilterChip[] = []
+	if (oxygen !== 'any')
+		chips.push({
+			label: `Oxygen clean: ${oxygen === 'yes' ? 'Yes' : 'No'}`,
+			onClear: () => setOxygen('any'),
+		})
+	if (needsVis !== 'any')
+		chips.push({
+			label: needsVis === 'yes' ? 'Needs vis' : 'Vis current',
+			onClear: () => setNeedsVis('any'),
+		})
+	if (outOfHydro !== 'any')
+		chips.push({
+			label: outOfHydro === 'yes' ? 'Out of hydro' : 'Hydro current',
+			onClear: () => setOutOfHydro('any'),
+		})
+	if (owner)
+		chips.push({ label: `Owner: ${owner.name}`, onClear: () => setOwner(null) })
+
+	const clearAll = () => {
+		setOxygen('any')
+		setNeedsVis('any')
+		setOutOfHydro('any')
+		setOwner(null)
+	}
+
+	return (
+		<div className='w-full'>
+			<TableToolbar
+				filters={
+					<>
+						<div className='w-40'>
+							<ListBox
+								items={YES_NO_ANY_OPTIONS}
+								title='Oxygen clean'
+								id='filter-oxygen'
+								name='filter-oxygen'
+								value={triItem(oxygen)}
+								onChange={(item) => setOxygen(item.value as TriState)}
+							/>
+						</div>
+						<div className='w-40'>
+							<ListBox
+								items={YES_NO_ANY_OPTIONS}
+								title='Needs vis'
+								id='filter-needs-vis'
+								name='filter-needs-vis'
+								value={triItem(needsVis)}
+								onChange={(item) => setNeedsVis(item.value as TriState)}
+							/>
+						</div>
+						<div className='w-40'>
+							<ListBox
+								items={YES_NO_ANY_OPTIONS}
+								title='Out of hydro'
+								id='filter-out-hydro'
+								name='filter-out-hydro'
+								value={triItem(outOfHydro)}
+								onChange={(item) => setOutOfHydro(item.value as TriState)}
+							/>
+						</div>
+						<div className='w-60'>
+							<ClientPicker
+								disableAdd
+								value={owner}
+								onChange={setOwner}
+							/>
+						</div>
+					</>
+				}
+				sort={
+					<div className='w-60'>
+						<ListBox
+							items={CYLINDER_SORT_OPTIONS}
+							title='Sort by'
+							id='cylinder-sort'
+							name='cylinder-sort'
+							value={
+								CYLINDER_SORT_OPTIONS.find((o) => o.value === sortValue) ??
+								CYLINDER_SORT_OPTIONS[0]
+							}
+							onChange={(item) => setSortValue(item.value)}
+						/>
+					</div>
+				}
+				chips={chips}
+				onClearAll={chips.length > 0 ? clearAll : undefined}
+			/>
+			<CylinderListTable cylinders={filtered} showOwner />
+		</div>
+	)
+}
+
+export default CylindersTab
+```
+
+- [ ] **Step 2: Verify lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 3: Manual check (deferred)**
+
+Component is not yet mounted; the real browser check happens in Task 8. For now confirm the file compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/History/CylindersTab.tsx
+git commit -m "feat: add CylindersTab with filter and sort controls"
+```
+
+---
+
+## Task 7: Build `FillsTab` with filters and sort
+
+Same pattern as `CylindersTab`. Loads fills via `useLoadFills`, owns mix/cylinder/owner filter state plus sort state, and renders `<FillHistoryTable fills={filtered} />`.
+
+**Files:**
+- Create: `src/components/History/FillsTab.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+'use client'
+
+import { useMemo, useState } from 'react'
+import dayjs from 'dayjs'
+import { FillHistory } from '@/types/fills'
+import { Cylinder } from '@/types/cylinder'
+import { Client } from '@/types/client'
+import FillHistoryTable from '@/components/History/components/FillHistoryTable'
+import TableToolbar, { FilterChip } from '@/components/UI/TableToolbar'
+import ListBox from '@/components/UI/FormElements/ListBox'
+import ClientPicker from '@/components/UI/FormElements/ClientPicker'
+import CylinderPicker from '@/components/UI/FormElements/CylinderPicker'
+import useLoadFills from '@/hooks/useLoadFills'
+import useTableFilters from '@/hooks/useTableFilters'
+import { getFillCategory, FillMixCategory } from '@/lib/fills'
+import {
+	FILL_SORT_OPTIONS,
+	MIX_TYPE_OPTIONS,
+} from '@/app/constants/FormConstants'
+
+type MixFilter = 'any' | FillMixCategory
+
+const sortByValue: Record<string, (a: FillHistory, b: FillHistory) => number> =
+	{
+		'date-desc': (a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf(),
+		'date-asc': (a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf(),
+		'mix-asc': (a, b) => getFillCategory(a).localeCompare(getFillCategory(b)),
+	}
+
+const mixItem = (mix: MixFilter) =>
+	MIX_TYPE_OPTIONS.find((o) => o.value === mix) ?? MIX_TYPE_OPTIONS[0]
+
+const FillsTab = () => {
+	const { fills } = useLoadFills()
+	const [mix, setMix] = useState<MixFilter>('any')
+	const [cylinder, setCylinder] = useState<Cylinder | null>(null)
+	const [owner, setOwner] = useState<Client | null>(null)
+	const [sortValue, setSortValue] = useState<string>('date-desc')
+
+	const predicates = useMemo(() => {
+		const list: Array<(f: FillHistory) => boolean> = []
+		if (mix !== 'any') {
+			list.push((f) => getFillCategory(f) === mix)
+		}
+		if (cylinder) {
+			list.push((f) => f.Cylinder.id === cylinder.id)
+		}
+		if (owner) {
+			list.push((f) => f.Cylinder.Client?.id === owner.id)
+		}
+		return list
+	}, [mix, cylinder, owner])
+
+	const sort = sortByValue[sortValue]
+	const filtered = useTableFilters(fills, { predicates, sort })
+
+	const chips: FilterChip[] = []
+	if (mix !== 'any')
+		chips.push({
+			label: `Mix: ${mix[0].toUpperCase()}${mix.slice(1)}`,
+			onClear: () => setMix('any'),
+		})
+	if (cylinder)
+		chips.push({
+			label: `Cylinder: ${cylinder.nickname ?? cylinder.serialNumber}`,
+			onClear: () => setCylinder(null),
+		})
+	if (owner)
+		chips.push({
+			label: `Owner: ${owner.name}`,
+			onClear: () => setOwner(null),
+		})
+
+	const clearAll = () => {
+		setMix('any')
+		setCylinder(null)
+		setOwner(null)
+	}
+
+	return (
+		<div className='w-full'>
+			<TableToolbar
+				filters={
+					<>
+						<div className='w-40'>
+							<ListBox
+								items={MIX_TYPE_OPTIONS}
+								title='Mix type'
+								id='filter-mix'
+								name='filter-mix'
+								value={mixItem(mix)}
+								onChange={(item) => setMix(item.value as MixFilter)}
+							/>
+						</div>
+						<div className='w-60'>
+							<CylinderPicker
+								value={cylinder}
+								onChange={(c) => setCylinder(c ?? null)}
+							/>
+						</div>
+						<div className='w-60'>
+							<ClientPicker disableAdd value={owner} onChange={setOwner} />
+						</div>
+					</>
+				}
+				sort={
+					<div className='w-60'>
+						<ListBox
+							items={FILL_SORT_OPTIONS}
+							title='Sort by'
+							id='fill-sort'
+							name='fill-sort'
+							value={
+								FILL_SORT_OPTIONS.find((o) => o.value === sortValue) ??
+								FILL_SORT_OPTIONS[0]
+							}
+							onChange={(item) => setSortValue(item.value)}
+						/>
+					</div>
+				}
+				chips={chips}
+				onClearAll={chips.length > 0 ? clearAll : undefined}
+			/>
+			<FillHistoryTable fills={filtered} />
+		</div>
+	)
+}
+
+export default FillsTab
+```
+
+`CylinderPicker`'s `onChange` is typed `(c?: Cylinder) => void` (callback arg is `Cylinder | undefined`), so the wrapper `(c) => setCylinder(c ?? null)` normalizes the picker's undefined to the tab's `null` state.
+
+- [ ] **Step 2: Verify lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/History/FillsTab.tsx
+git commit -m "feat: add FillsTab with filter and sort controls"
+```
+
+---
+
+## Task 8: Wire tabs into `app/history/page.tsx`
+
+Replace the `<CylinderListTable cylinders=… showOwner />` and `<FillHistoryTable />` cases with the new tab components.
+
+**Files:**
+- Modify: `src/app/history/page.tsx`
+
+- [ ] **Step 1: Replace tab render with the new components**
+
+Edit the imports and the `getTabComponent` switch:
+
+```tsx
+'use client'
+
+import { Suspense } from 'react'
+import MaintenanceHistory from '@/components/History/MaintenanceHistory/MaintenanceHistory'
+import VisHistory from '@/components/History/VisHistory'
+import ClientList from '@/components/History/ClientList'
+import CylindersTab from '@/components/History/CylindersTab'
+import FillsTab from '@/components/History/FillsTab'
+import useLoadCylinder from '@/hooks/useLoadCylinders'
+import { useSearchParams } from 'next/navigation'
+import { TAB } from './layout'
+
+const HistoryContent = () => {
+	const params = useSearchParams()
+
+	const { cylinders } = useLoadCylinder()
+
+	const getTabComponent = () => {
+		switch (params.get('tab')) {
+			case TAB.FILLS:
+				return <FillsTab />
+			case TAB.VIS_INSPECTION:
+				return <VisHistory />
+			case TAB.COMP_MAINTENANCE:
+				return <MaintenanceHistory />
+			case TAB.CLIENTS:
+				return <ClientList />
+			case TAB.CYLINDERS:
+				return <CylindersTab cylinders={cylinders} />
+			default:
+				return <FillsTab />
+		}
+	}
+
+	return (
+		<div className='container flex w-full flex-wrap justify-center'>
+			{getTabComponent()}
+		</div>
+	)
+}
+
+export default function History() {
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<HistoryContent />
+		</Suspense>
+	)
+}
+```
+
+Delete the unused `FillHistoryTable` import (the inner table is rendered by `FillsTab` now).
+
+- [ ] **Step 2: Verify lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 3: Manual check — cylinders tab**
+
+Open `/history?tab=CYLINDERS` in dev. Confirm:
+- The toolbar renders above the table with Oxygen clean, Needs vis, Out of hydro, Owner, and Sort by controls.
+- Changing each filter updates the visible rows.
+- Active filters show as chips below the controls.
+- Clicking a chip clears that filter; "Clear all" appears and resets everything.
+- Switching sort changes the row order.
+- On a phone width the toolbar wraps and remains usable.
+
+- [ ] **Step 4: Manual check — fills tab**
+
+Open `/history?tab=FILLS`. Confirm:
+- Mix type filter narrows by air / nitrox / trimix.
+- Cylinder picker narrows to a single cylinder's fills.
+- Owner picker narrows to fills for that client's cylinders.
+- Sort dropdown changes order (default newest-first).
+- Chips + clear all behave as in the cylinders tab.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/history/page.tsx
+git commit -m "feat: wire filter/sort tabs into history page"
+```
+
+---
+
+## Out of scope reminders
+
+Confirm none of the following slipped in:
+- URL param persistence
+- Filtering/sorting on vis, audit, user, or client tables
+- Filtering fills by date range
+- Sorting fills by cylinder or end pressure
+- Server-side filtering
+
+These are explicitly deferred per the spec.

--- a/docs/superpowers/specs/2026-05-18-table-filters-design.md
+++ b/docs/superpowers/specs/2026-05-18-table-filters-design.md
@@ -1,0 +1,153 @@
+# Table filters & sort — design
+
+History page tables (cylinders, fills) need filtering and sorting so users
+can find specific cylinders or fills without scrolling. Same UX pattern
+applies to both tables.
+
+## Shared infrastructure
+
+### `<TableToolbar>` component
+
+Renders above a table. Props:
+
+- `children`: filter controls (`ListBox`, `ClientPicker`, `CylinderPicker`, …)
+- `activeFilters`: `Array<{ label: string; onClear: () => void }>` — drives the
+  chip row and the "Clear all" button (also hidden when empty)
+- `onClearAll`: `() => void`
+
+Layout:
+
+```
+┌───────────────────────────────────────────────────────┐
+│ ▼ Oxygen  ▼ Vis  ▼ Hydro  ▼ Owner       Sort: ▼ Field │
+│ [Needs vis ✕]  [Owner: Marshall ✕]      Clear all     │
+└───────────────────────────────────────────────────────┘
+```
+
+Filter row wraps on small screens (`flex flex-wrap gap-2`). Chip row hidden
+when no filters active.
+
+### `useTableFilters<T>` hook
+
+```ts
+useTableFilters<T>(items: T[], {
+  predicates: Array<(item: T) => boolean>,
+  sort?: (a: T, b: T) => number,
+}): T[]
+```
+
+- Applies all predicates with AND (any predicate returning `false` rejects the
+  item)
+- Applies `sort` after filtering
+- Memoized so downstream `usePagination` stays stable when inputs don't change
+- Returns a new array; caller passes the result into `usePagination`
+
+Composition pattern:
+
+```ts
+const filtered = useTableFilters(items, { predicates, sort })
+const { paginatedItems, page, setPage, totalPages } = usePagination(filtered)
+```
+
+## Where the toolbar lives
+
+Toolbar mounts on the history page (`src/app/history/page.tsx`), not inside the
+table component. The history page owns filter/sort state via `useState`, runs
+the items through `useTableFilters`, and passes the result into the table as
+its existing `cylinders` / `fills` prop.
+
+Rationale:
+
+- Tables stay generic — they keep accepting a flat list and rendering it
+- A future move to URL params is a one-page change
+- Toolbar is per-tab, so it lives where the tab routing lives
+
+The non-history caller (`/app/clients/[slug]`, etc., if they reuse
+`CylinderListTable`) keeps working — they just don't render a toolbar.
+
+## Cylinders (#5)
+
+### Filter controls
+
+| Filter | Control | Predicate |
+|---|---|---|
+| Oxygen clean | `ListBox`: Any / Yes / No | `value === 'any' \|\| cylinder.oxygenClean === (value === 'yes')` |
+| Needs vis | `ListBox`: Any / Yes / No | derived from `dayjs(lastVis).add(1, 'year').isBefore(now)` |
+| Out of hydro | `ListBox`: Any / Yes / No | derived from `dayjs(lastHydro).add(5, 'year').isBefore(now)` |
+| Owner | `ClientPicker` (controlled, `disableAdd`) | `cylinder.ownerId === client.id` |
+
+### Sort options
+
+Single `ListBox` with combined field+direction options:
+
+- Serial / nickname (A→Z) — default
+- Last vis (oldest first)
+- Last vis (newest first)
+- Last hydro (oldest first)
+- Last hydro (newest first)
+
+Sort comparators live next to the options in a small lookup map (keyed by the
+ListBox value).
+
+### Active filter chips
+
+- `Oxygen clean: Yes` (clears to Any)
+- `Needs vis` (clears to Any) — single label since the affirmative is the
+  interesting case; "No" reads as "any" effectively
+- `Out of hydro` (clears to Any)
+- `Owner: <client name>` (clears the picker)
+
+## Fill history (#8)
+
+### Filter controls
+
+| Filter | Control | Predicate |
+|---|---|---|
+| Mix type | `ListBox`: Any / Air / Nitrox / Trimix | category derived from `oxygen` / `helium`: `helium > 0 → trimix`, `oxygen === 20.9 → air`, else `nitrox` |
+| Cylinder | `CylinderPicker` (controlled, `disableAdd`) | `fill.Cylinder.id === cylinder.id` |
+| Owner | `ClientPicker` (controlled, `disableAdd`) | `fill.Cylinder.Client?.id === client.id` |
+
+### Sort options
+
+- Date (newest first) — default
+- Date (oldest first)
+- Mix type (alphabetical)
+
+### Active filter chips
+
+- `Mix: Air` (clears to Any)
+- `Cylinder: <nickname or serial>` (clears the picker)
+- `Owner: <client name>` (clears the picker)
+
+## Constants
+
+Sort option lists, "needs vis" / "out of hydro" thresholds, and the mix-type
+categorization already exist in code:
+
+- Add `CYLINDER_SORT_OPTIONS` and `FILL_SORT_OPTIONS` to
+  `src/app/constants/FormConstants.ts` alongside existing `ROLE_OPTIONS`
+- Add a `getFillCategory(fill)` helper next to existing `getFillMix` (or
+  extract both to `src/lib/fills.ts`) returning `'air' | 'nitrox' | 'trimix'`
+  for the predicate
+
+## State
+
+- All filter/sort state lives in `app/history/page.tsx` via `useState`
+- Survives tab switches via the existing tab routing (history page stays
+  mounted); resets on full navigation away
+- No URL params (deferred — toolbar location keeps this a small future change)
+
+## Out of scope
+
+- URL param persistence
+- Saving filter presets
+- Server-side filtering (table sizes are small enough for client filtering)
+- Filtering on the audit log, user list, or client list tables
+- Sorting fills by cylinder name or end pressure (user opted out)
+- Filtering fills by date range (user opted out)
+
+## Build order
+
+1. `<TableToolbar>` component + `useTableFilters` hook + sort-option constants
+2. Wire cylinder filters/sort into the history page → `CylinderListTable`
+3. Wire fill filters/sort into the history page → `FillHistoryTable`

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/_api/index.ts
+++ b/src/app/_api/index.ts
@@ -122,6 +122,28 @@ export async function newMaintenance(
 	return result.status == 201 ? result.data : result.data.message
 }
 
+export async function updateMaintenance(
+	id: number,
+	record: { date: string; hours: number; description: string },
+): Promise<CompressorMaintenance | string> {
+	const result = await axiosInstance.put(`/api/maintenance/${id}`, record)
+	return result.status == 200 ? result.data : result.data.message
+}
+
+export async function updateFill(
+	id: number,
+	fill: {
+		date: string
+		startPressure: number
+		endPressure: number
+		oxygen: number
+		helium: number
+	},
+): Promise<FillHistory | string> {
+	const result = await axiosInstance.put(`/api/fills/${id}`, fill)
+	return result.status == 200 ? result.data : result.data.message
+}
+
 export async function addNewFill(fills: FillDto[]): Promise<Fill[] | string> {
 	const result = await axiosInstance.post('/api/fills', fills)
 

--- a/src/app/api/cylinders/route.tsx
+++ b/src/app/api/cylinders/route.tsx
@@ -1,4 +1,5 @@
 import { Cylinder } from '@/lib/models/cylinder'
+import { Client } from '@/lib/models/client'
 import dayjs from 'dayjs'
 import { requireRole, isErrorResponse } from '@/lib/permissions-server'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
@@ -8,7 +9,9 @@ export async function GET(request: Request) {
 	const result = await requireRole(['filler', 'inspector', 'admin'])
 	if (isErrorResponse(result)) return result
 
-	const cylinders = await Cylinder.findAll()
+	const cylinders = await Cylinder.findAll({
+		include: [{ model: Client, attributes: ['id', 'name'] }],
+	})
 
 	return Response.json(cylinders)
 }

--- a/src/app/api/fills/[id]/route.tsx
+++ b/src/app/api/fills/[id]/route.tsx
@@ -1,0 +1,61 @@
+import { Fill } from '@/lib/models/fill'
+import { requireRole, isErrorResponse } from '@/lib/permissions-server'
+import { auditLog } from '@/lib/audit'
+import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+dayjs.extend(customParseFormat)
+
+export async function PUT(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const result = await requireRole(['admin'])
+	if (isErrorResponse(result)) return result
+
+	const { id } = await params
+	const fill = await Fill.findByPk(id)
+	if (!fill) {
+		return Response.json(
+			{ error: 'not_found', message: 'Fill not found' },
+			{ status: 404 },
+		)
+	}
+
+	const { date, startPressure, endPressure, oxygen, helium } =
+		await request.json()
+
+	const before = {
+		date: fill.date.toISOString(),
+		startPressure: fill.startPressure,
+		endPressure: fill.endPressure,
+		oxygen: fill.oxygen,
+		helium: fill.helium,
+	}
+
+	fill.date = dayjs(date)
+	fill.startPressure = Number(startPressure)
+	fill.endPressure = Number(endPressure)
+	fill.oxygen = Number(oxygen)
+	fill.helium = Number(helium)
+
+	try {
+		const saved = await fill.save()
+		await auditLog(result.user!.id!, 'update', 'fill', id, {
+			before,
+			after: {
+				date: fill.date.toISOString(),
+				startPressure: fill.startPressure,
+				endPressure: fill.endPressure,
+				oxygen: fill.oxygen,
+				helium: fill.helium,
+			},
+		})
+		return Response.json(saved)
+	} catch (err: any) {
+		console.error('error:', err)
+		return Response.json(
+			{ error: err.name, message: err.errors?.[0]?.message ?? err.message },
+			{ status: 400 },
+		)
+	}
+}

--- a/src/app/api/fills/route.tsx
+++ b/src/app/api/fills/route.tsx
@@ -1,4 +1,5 @@
 import { Cylinder } from '@/lib/models/cylinder'
+import { Client } from '@/lib/models/client'
 import { Fill } from '@/lib/models/fill'
 import { requireRole, isErrorResponse } from '@/lib/permissions-server'
 import { FillDto } from '@/types/fills'
@@ -8,7 +9,12 @@ export async function GET() {
 	if (isErrorResponse(result)) return result
 
 	const fills = await Fill.findAll({
-		include: Cylinder,
+		include: [
+			{
+				model: Cylinder,
+				include: [{ model: Client, attributes: ['id', 'name'] }],
+			},
+		],
 	})
 	return Response.json(fills)
 }

--- a/src/app/api/maintenance/[id]/route.tsx
+++ b/src/app/api/maintenance/[id]/route.tsx
@@ -1,0 +1,54 @@
+import { Maintenance } from '@/lib/models/maintenance'
+import { requireRole, isErrorResponse } from '@/lib/permissions-server'
+import { auditLog } from '@/lib/audit'
+import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+dayjs.extend(customParseFormat)
+
+export async function PUT(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const result = await requireRole(['admin'])
+	if (isErrorResponse(result)) return result
+
+	const { id } = await params
+	const record = await Maintenance.findByPk(id)
+	if (!record) {
+		return Response.json(
+			{ error: 'not_found', message: 'Maintenance record not found' },
+			{ status: 404 },
+		)
+	}
+
+	const { date, hours, description } = await request.json()
+
+	const before = {
+		date: record.date.toISOString(),
+		hours: record.hours,
+		description: record.description,
+	}
+
+	record.date = dayjs(date)
+	record.hours = Number(hours)
+	record.description = description ?? ''
+
+	try {
+		const saved = await record.save()
+		await auditLog(result.user!.id!, 'update', 'maintenance', id, {
+			before,
+			after: {
+				date: record.date.toISOString(),
+				hours: record.hours,
+				description: record.description,
+			},
+		})
+		return Response.json(saved)
+	} catch (err: any) {
+		console.error('error:', err)
+		return Response.json(
+			{ error: err.name, message: err.errors?.[0]?.message ?? err.message },
+			{ status: 400 },
+		)
+	}
+}

--- a/src/app/clients/[slug]/page.tsx
+++ b/src/app/clients/[slug]/page.tsx
@@ -2,18 +2,29 @@
 
 import AddCylinderButton from '@/components/Dashboard/AddCylinderButton'
 import CylinderListTable from '@/components/Cylinders/CylinderListTable'
+import FillHistoryTable from '@/components/History/components/FillHistoryTable'
 import FormGroup from '@/components/UI/FormGroup'
 import PropertyRow from '@/components/VisHistory/PropertyRow'
+import ClientDetailsTabs, {
+	ClientDetailsTab,
+} from '@/components/Clients/ClientDetailsTabs'
 import { Client } from '@/lib/models/client'
 import { Cylinder } from '@/lib/models/cylinder'
 import { Fill } from '@/lib/models/fill'
 
+const isTab = (value: unknown): value is ClientDetailsTab =>
+	value === 'cylinders' || value === 'fills'
+
 export default async function ClientDetails({
 	params,
+	searchParams,
 }: {
 	params: Promise<{ slug: string }>
+	searchParams: Promise<{ tab?: string }>
 }) {
 	const { slug: clientId } = await params
+	const { tab } = await searchParams
+	const activeTab: ClientDetailsTab = isTab(tab) ? tab : 'cylinders'
 
 	const client = await Client.findByPk(clientId, {
 		include: Cylinder,
@@ -25,6 +36,15 @@ export default async function ClientDetails({
 		cylinderIds.length > 0
 			? await Fill.count({ where: { CylinderId: cylinderIds } })
 			: 0
+
+	const fills =
+		activeTab === 'fills' && cylinderIds.length > 0
+			? await Fill.findAll({
+					where: { CylinderId: cylinderIds },
+					include: [{ model: Cylinder }],
+					order: [['date', 'DESC']],
+				})
+			: []
 
 	return (
 		<div className='max-w-7xl'>
@@ -50,17 +70,25 @@ export default async function ClientDetails({
 						<PropertyRow title='Total Fills' text={String(totalFills)} />
 					</div>
 				</FormGroup>
-				<div className='flex flex-col items-center justify-center gap-3 py-6'>
-					<h1 className='text-text text-2xl font-semibold'>Cylinders</h1>
+
+				<div className='mt-6'>
+					<ClientDetailsTabs clientId={clientId} activeTab={activeTab} />
 				</div>
 
-				{client && (
-					<div className='flex w-full justify-end px-6'>
-						<AddCylinderButton client={JSON.parse(JSON.stringify(client))} />
-					</div>
+				{activeTab === 'cylinders' ? (
+					<>
+						{client && (
+							<div className='mt-4 flex w-full justify-end px-6'>
+								<AddCylinderButton
+									client={JSON.parse(JSON.stringify(client))}
+								/>
+							</div>
+						)}
+						<CylinderListTable cylinders={cylinders} />
+					</>
+				) : (
+					<FillHistoryTable fills={JSON.parse(JSON.stringify(fills))} />
 				)}
-
-				<CylinderListTable cylinders={cylinders} />
 			</div>
 		</div>
 	)

--- a/src/app/constants/FormConstants.ts
+++ b/src/app/constants/FormConstants.ts
@@ -97,3 +97,30 @@ export function servicePressureOptions(
 		value: String(p),
 	}))
 }
+
+export const YES_NO_ANY_OPTIONS = [
+	{ name: 'Any', value: 'any' },
+	{ name: 'Yes', value: 'yes' },
+	{ name: 'No', value: 'no' },
+]
+
+export const MIX_TYPE_OPTIONS = [
+	{ name: 'Any mix', value: 'any' },
+	{ name: 'Air', value: 'air' },
+	{ name: 'Nitrox', value: 'nitrox' },
+	{ name: 'Trimix', value: 'trimix' },
+]
+
+export const CYLINDER_SORT_OPTIONS = [
+	{ name: 'Serial (A→Z)', value: 'serial-asc' },
+	{ name: 'Last vis (oldest first)', value: 'lastVis-asc' },
+	{ name: 'Last vis (newest first)', value: 'lastVis-desc' },
+	{ name: 'Last hydro (oldest first)', value: 'lastHydro-asc' },
+	{ name: 'Last hydro (newest first)', value: 'lastHydro-desc' },
+]
+
+export const FILL_SORT_OPTIONS = [
+	{ name: 'Date (newest first)', value: 'date-desc' },
+	{ name: 'Date (oldest first)', value: 'date-asc' },
+	{ name: 'Mix type (A→Z)', value: 'mix-asc' },
+]

--- a/src/app/history/layout.tsx
+++ b/src/app/history/layout.tsx
@@ -1,11 +1,18 @@
 'use client'
 
-import { ReactNode, Suspense } from 'react'
+import { ReactNode, Suspense, useState } from 'react'
 import clsx from 'clsx'
 
-import { ClockIcon, EyeIcon, UsersIcon } from '@heroicons/react/24/outline'
+import {
+	Bars3Icon,
+	ClockIcon,
+	EyeIcon,
+	UsersIcon,
+	XMarkIcon,
+} from '@heroicons/react/24/outline'
 import AirTank from '@/icons/AirTank'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { Dialog, DialogPanel } from '@headlessui/react'
 
 export enum TAB {
 	FILLS = 'FILLS',
@@ -27,68 +34,115 @@ const navigation = [
 	},
 ]
 
+type NavListProps = {
+	selectedTab: string
+	onSelect: (value: TAB) => void
+}
+
+const NavList = ({ selectedTab, onSelect }: NavListProps) => (
+	<ul role='list' className='-mx-2 mt-2 space-y-1'>
+		{navigation.map((item) => (
+			<li key={item.name}>
+				<button
+					onClick={() => onSelect(item.value)}
+					className={clsx(
+						item.value === selectedTab
+							? 'bg-surface text-accent-text'
+							: 'text-text hover:bg-hover hover:text-accent-text',
+						'group flex w-full cursor-pointer gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
+					)}
+				>
+					<item.icon
+						aria-hidden='true'
+						className={clsx(
+							item.value === selectedTab
+								? 'text-accent-text'
+								: 'text-muted-text group-hover:text-accent-text',
+							'size-6 shrink-0',
+						)}
+					/>
+					{item.name}
+				</button>
+			</li>
+		))}
+	</ul>
+)
+
 const LayoutContent = ({ children }: { children: ReactNode }) => {
 	const router = useRouter()
 	const params = useSearchParams()
+	const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
 	const tab = params.get('tab')
 
 	const selectedTab = (Object.values(TAB) as Array<unknown>).includes(tab)
-		? tab
+		? (tab as string)
 		: TAB.FILLS
+
+	const selectedName =
+		navigation.find((n) => n.value === selectedTab)?.name ?? 'History'
+
+	const handleSelect = (value: TAB) => {
+		router.push(`/history?tab=${value}`)
+		setMobileNavOpen(false)
+	}
 
 	return (
 		<div className='border-border flex grow border-t'>
-			{/* Static sidebar for desktop */}
-			<div className='fixed inset-y-0 z-50 flex w-72 flex-col'>
-				{/* Sidebar component, swap this element with another sidebar if you like */}
+			{/* Desktop sidebar */}
+			<div className='fixed inset-y-0 z-50 hidden w-72 flex-col lg:flex'>
 				<div className='border-border bg-background mt-24 flex grow flex-col gap-y-5 overflow-y-auto border-t border-r px-6'>
 					<nav className='flex flex-1 flex-col'>
-						<ul role='list' className='flex flex-1 flex-col gap-y-7'>
-							<li>
-								<ul role='list' className='flex flex-1 flex-col gap-y-7'>
-									<li>
-										<ul role='list' className='-mx-2 mt-2 space-y-1'>
-											{navigation.map((item) => (
-												<li key={item.name}>
-													<button
-														onClick={() =>
-															router.push(`/history?tab=${item.value}`)
-														}
-														className={clsx(
-															item.value === selectedTab
-																? 'bg-surface text-accent-text'
-																: 'text-text hover:bg-hover hover:text-accent-text',
-															'group flex w-full cursor-pointer gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
-														)}
-													>
-														<item.icon
-															aria-hidden='true'
-															className={clsx(
-																item.value === selectedTab
-																	? 'text-accent-text'
-																	: 'text-muted-text group-hover:text-accent-text',
-																'size-6 shrink-0',
-															)}
-														/>
-														{item.name}
-													</button>
-												</li>
-											))}
-										</ul>
-									</li>
-								</ul>
-							</li>
-						</ul>
+						<NavList selectedTab={selectedTab} onSelect={handleSelect} />
 					</nav>
 				</div>
 			</div>
 
-			<div className='min-w-full py-10 pl-72'>
+			<div className='min-w-full py-6 lg:py-10 lg:pl-72'>
+				{/* Mobile tab bar */}
+				<div className='border-border bg-background flex items-center justify-between border-b px-4 py-3 lg:hidden'>
+					<span className='text-text text-base font-semibold'>
+						{selectedName}
+					</span>
+					<button
+						type='button'
+						onClick={() => setMobileNavOpen(true)}
+						className='text-text hover:bg-hover -m-2 inline-flex cursor-pointer items-center justify-center rounded-md p-2'
+					>
+						<span className='sr-only'>Open history menu</span>
+						<Bars3Icon aria-hidden='true' className='size-6' />
+					</button>
+				</div>
+
 				<div className='flex justify-center px-4 sm:px-6 lg:px-8'>
 					{children}
 				</div>
 			</div>
+
+			{/* Mobile drawer */}
+			<Dialog
+				open={mobileNavOpen}
+				onClose={setMobileNavOpen}
+				className='lg:hidden'
+			>
+				<div className='fixed inset-0 z-50 bg-black/30' aria-hidden='true' />
+				<DialogPanel className='bg-background sm:ring-border fixed inset-y-0 left-0 z-50 w-full max-w-xs overflow-y-auto p-6 sm:ring-1'>
+					<div className='flex items-center justify-between'>
+						<span className='text-text text-base font-semibold'>History</span>
+						<button
+							type='button'
+							onClick={() => setMobileNavOpen(false)}
+							className='text-text hover:bg-hover -m-2 rounded-md p-2'
+						>
+							<span className='sr-only'>Close menu</span>
+							<XMarkIcon aria-hidden='true' className='size-6' />
+						</button>
+					</div>
+					<nav className='mt-6'>
+						<NavList selectedTab={selectedTab} onSelect={handleSelect} />
+					</nav>
+				</DialogPanel>
+			</Dialog>
 		</div>
 	)
 }

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -2,10 +2,10 @@
 
 import { Suspense } from 'react'
 import MaintenanceHistory from '@/components/History/MaintenanceHistory/MaintenanceHistory'
-import FillHistoryTable from '@/components/History/components/FillHistoryTable'
 import VisHistory from '@/components/History/VisHistory'
 import ClientList from '@/components/History/ClientList'
-import CylinderListTable from '@/components/Cylinders/CylinderListTable'
+import CylindersTab from '@/components/History/CylindersTab'
+import FillsTab from '@/components/History/FillsTab'
 import useLoadCylinder from '@/hooks/useLoadCylinders'
 import { useSearchParams } from 'next/navigation'
 import { TAB } from './layout'
@@ -18,7 +18,7 @@ const HistoryContent = () => {
 	const getTabComponent = () => {
 		switch (params.get('tab')) {
 			case TAB.FILLS:
-				return <FillHistoryTable />
+				return <FillsTab />
 			case TAB.VIS_INSPECTION:
 				return <VisHistory />
 			case TAB.COMP_MAINTENANCE:
@@ -26,9 +26,9 @@ const HistoryContent = () => {
 			case TAB.CLIENTS:
 				return <ClientList />
 			case TAB.CYLINDERS:
-				return <CylinderListTable cylinders={cylinders} showOwner />
+				return <CylindersTab cylinders={cylinders} />
 			default:
-				return <FillHistoryTable />
+				return <FillsTab />
 		}
 	}
 

--- a/src/components/Clients/ClientDetailsTabs.tsx
+++ b/src/components/Clients/ClientDetailsTabs.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import clsx from 'clsx'
+import Link from 'next/link'
+
+export type ClientDetailsTab = 'cylinders' | 'fills'
+
+const tabs: Array<{ value: ClientDetailsTab; label: string }> = [
+	{ value: 'cylinders', label: 'Cylinders' },
+	{ value: 'fills', label: 'Fills' },
+]
+
+type ClientDetailsTabsProps = {
+	clientId: string
+	activeTab: ClientDetailsTab
+}
+
+const ClientDetailsTabs = ({ clientId, activeTab }: ClientDetailsTabsProps) => {
+	return (
+		<div className='border-border flex border-b'>
+			{tabs.map((tab) => (
+				<Link
+					key={tab.value}
+					href={`/clients/${clientId}?tab=${tab.value}`}
+					replace
+					scroll={false}
+					className={clsx(
+						'px-4 py-2 text-sm font-semibold transition',
+						tab.value === activeTab
+							? 'border-accent text-accent-text -mb-px border-b-2'
+							: 'text-light-text hover:text-text',
+					)}
+				>
+					{tab.label}
+				</Link>
+			))}
+		</div>
+	)
+}
+
+export default ClientDetailsTabs

--- a/src/components/Cylinders/CylinderListRow.tsx
+++ b/src/components/Cylinders/CylinderListRow.tsx
@@ -56,18 +56,19 @@ const CylinderListRow = ({
 				)}
 			</td>
 			{showOwner && (
-				<th
-					scope='col'
-					className='text-text py-3.5 pr-3 pl-4 text-center text-sm font-semibold sm:pl-6'
-				>
-					<Link
-						href={`/clients/${cylinder.ownerId}`}
-						className='bg-card-hover hover:bg-hover flex cursor-pointer flex-col items-center justify-between gap-2 p-6 transition sm:p-10'
-					>
-						{cylinder.ownerId}
-						<InformationCircleIcon />
-					</Link>
-				</th>
+				<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
+					{cylinder.ownerId ? (
+						<Link
+							href={`/clients/${cylinder.ownerId}`}
+							className='hover:text-accent inline-flex items-center gap-1 underline-offset-2 hover:underline'
+						>
+							<span>{cylinder.Client?.name ?? `#${cylinder.ownerId}`}</span>
+							<InformationCircleIcon className='h-4 w-4' />
+						</Link>
+					) : (
+						<span className='text-light-text'>—</span>
+					)}
+				</td>
 			)}
 			<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
 				<span className='flex w-full justify-center'>

--- a/src/components/Cylinders/CylinderListRow.tsx
+++ b/src/components/Cylinders/CylinderListRow.tsx
@@ -84,19 +84,19 @@ const CylinderListRow = ({
 			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
 				{dayjs(cylinder.lastVis).format('MM/YYYY')}
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap md:table-cell'>
 				<Tooltip message={nextHydro.format('MM/YYYY')}>
 					{nextHydro.isBefore(dayjs()) ? 'now' : nextHydro.fromNow()}
 				</Tooltip>
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap md:table-cell'>
 				<Tooltip message={nextVis.format('MM/YYYY')}>
 					{nextVis.isBefore(dayjs()) ? 'now' : nextVis.fromNow()}
 				</Tooltip>
 			</td>
 
 			{!hideInspection && (
-				<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+				<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap md:table-cell'>
 					{nextHydro.isBefore(dayjs()) ? (
 						'Needs Hydro First'
 					) : (

--- a/src/components/Cylinders/CylinderListTable.tsx
+++ b/src/components/Cylinders/CylinderListTable.tsx
@@ -81,20 +81,20 @@ const CylinderListTable = ({
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold md:table-cell'
 									>
 										Next Hydro
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold md:table-cell'
 									>
 										Next Vis
 									</th>
 									{!hideInspection && (
 										<th
 											scope='col'
-											className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+											className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold md:table-cell'
 										>
 											Do Inspection
 										</th>

--- a/src/components/Cylinders/CylinderListTable.tsx
+++ b/src/components/Cylinders/CylinderListTable.tsx
@@ -4,13 +4,11 @@ import { Cylinder } from '@/types/cylinder'
 import { Cylinder as CylinderDB } from '@/lib/models/cylinder'
 
 import CylinderListRow from './CylinderListRow'
-import { useEffect, useState, useTransition } from 'react'
-import Button from '@/components/UI/Button'
-
-const ROWS_PER_PAGE = 20
+import Pagination from '@/components/UI/Pagination'
+import usePagination from '@/hooks/usePagination'
 
 type CylinderListProps = {
-	cylinders: Cylinder[] | CylinderDB[]
+	cylinders: Array<Cylinder | CylinderDB>
 	showOwner?: boolean
 	hideInspection?: boolean
 	disableEdit?: boolean
@@ -22,19 +20,12 @@ const CylinderListTable = ({
 	hideInspection = false,
 	disableEdit = false,
 }: CylinderListProps) => {
-	const [page, setPage] = useState(1)
-	const [, startTransition] = useTransition()
-
-	const start = (page - 1) * ROWS_PER_PAGE
-	const end = start + ROWS_PER_PAGE
-	const paginatedCylinders = cylinders.slice(start, end)
-	const totalPages = Math.ceil(cylinders.length / ROWS_PER_PAGE)
-
-	useEffect(() => {
-		startTransition(() => {
-			setPage(1)
-		})
-	}, [cylinders.length])
+	const {
+		page,
+		setPage,
+		totalPages,
+		paginatedItems: paginatedCylinders,
+	} = usePagination(cylinders)
 
 	return (
 		<div className='mt-8 flow-root'>
@@ -119,31 +110,11 @@ const CylinderListTable = ({
 								))}
 							</tbody>
 						</table>
-						{totalPages > 1 && (
-							<div className='flex items-center justify-between px-4 py-4'>
-								<p className='text-light-text text-sm'>
-									Page {page} of {totalPages}
-								</p>
-
-								<div className='flex gap-2'>
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.max(p - 1, 1))}
-										disabled={page === 1}
-									>
-										Previous
-									</Button>
-
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
-										disabled={page >= totalPages}
-									>
-										Next
-									</Button>
-								</div>
-							</div>
-						)}
+						<Pagination
+							page={page}
+							totalPages={totalPages}
+							onPageChange={setPage}
+						/>
 					</div>
 				</div>
 			</div>

--- a/src/components/Fills/FillType.tsx
+++ b/src/components/Fills/FillType.tsx
@@ -1,17 +1,25 @@
 import {
+	Dialog,
+	DialogPanel,
+	DialogTitle,
 	Label,
 	Listbox,
 	ListboxButton,
 	ListboxOption,
 	ListboxOptions,
 } from '@headlessui/react'
-import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/24/outline'
+import {
+	CheckIcon,
+	ChevronUpDownIcon,
+	ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline'
 import { updateFill } from '@/redux/fills/fillsSlice'
 import { useAppDispatch } from '@/redux/hooks'
 import { useState } from 'react'
 import { Fill, FillType as IFillType } from '@/types/fills'
 import { Client } from '@/types/client'
 import { Cylinder } from '@/types/cylinder'
+import Button from '../UI/Button'
 
 type FillTypeProps = {
 	index: number
@@ -23,8 +31,8 @@ type FillTypeProps = {
 type FillOption = {
 	value: IFillType
 	label: string
-	enabled: boolean
-	disabledReason?: string
+	certified: boolean
+	warning?: string
 }
 
 const FillType = ({ index, item, client, cylinder }: FillTypeProps) => {
@@ -37,22 +45,27 @@ const FillType = ({ index, item, client, cylinder }: FillTypeProps) => {
 		cylinder?.oxygenClean == true && !!(client && client.trimixCert)
 
 	const options: FillOption[] = [
-		{ value: 'air', label: 'Air', enabled: true },
+		{ value: 'air', label: 'Air', certified: true },
 		{
 			value: 'nitrox',
 			label: 'Nitrox',
-			enabled: nitroxUse,
-			disabledReason: 'Not certified for nitrox',
+			certified: nitroxUse,
+			warning: 'Client is not certified for nitrox',
 		},
 		{
 			value: 'trimix',
 			label: 'Trimix',
-			enabled: trimixUse,
-			disabledReason: 'Not certified for trimix',
+			certified: trimixUse,
+			warning: 'Client is not certified for trimix',
 		},
 	]
 
-	const handleTypeChange = (option: FillOption) => {
+	const [selectedFill, setSelectedFill] = useState<FillOption>(options[0])
+	const [pendingOverride, setPendingOverride] = useState<FillOption | null>(
+		null,
+	)
+
+	const applyChange = (option: FillOption) => {
 		setSelectedFill(option)
 		dispatch(
 			updateFill({
@@ -62,7 +75,18 @@ const FillType = ({ index, item, client, cylinder }: FillTypeProps) => {
 		)
 	}
 
-	const [selectedFill, setSelectedFill] = useState<FillOption>(options[0])
+	const handleTypeChange = (option: FillOption) => {
+		if (!option.certified) {
+			setPendingOverride(option)
+			return
+		}
+		applyChange(option)
+	}
+
+	const confirmOverride = () => {
+		if (pendingOverride) applyChange(pendingOverride)
+		setPendingOverride(null)
+	}
 
 	return (
 		<div className=''>
@@ -89,11 +113,16 @@ const FillType = ({ index, item, client, cylinder }: FillTypeProps) => {
 							<ListboxOption
 								key={option.value}
 								value={option}
-								disabled={!option.enabled}
-								title={option.enabled ? undefined : option.disabledReason}
-								className='group data-focus:bg-accent data-focus:text-white-text relative cursor-default py-2 pr-9 pl-3 data-disabled:cursor-not-allowed data-disabled:opacity-50'
+								title={option.certified ? undefined : option.warning}
+								className='group data-focus:bg-accent data-focus:text-white-text relative cursor-default py-2 pr-9 pl-3'
 							>
-								<span className='block truncate font-normal group-data-selected:font-semibold'>
+								<span className='flex items-center gap-2 truncate font-normal group-data-selected:font-semibold'>
+									{!option.certified && (
+										<ExclamationTriangleIcon
+											aria-hidden='true'
+											className='size-4 text-yellow-500'
+										/>
+									)}
 									{option.label}
 								</span>
 
@@ -105,6 +134,39 @@ const FillType = ({ index, item, client, cylinder }: FillTypeProps) => {
 					</ListboxOptions>
 				</div>
 			</Listbox>
+
+			<Dialog
+				open={pendingOverride !== null}
+				onClose={() => setPendingOverride(null)}
+				className='relative z-50'
+			>
+				<div className='fixed inset-0 bg-black/30' aria-hidden='true' />
+				<div className='fixed inset-0 flex items-center justify-center p-4'>
+					<DialogPanel className='bg-background border-border w-full max-w-md rounded-lg border p-6 shadow-xl'>
+						<div className='flex items-start gap-3'>
+							<ExclamationTriangleIcon
+								aria-hidden='true'
+								className='size-6 shrink-0 text-yellow-500'
+							/>
+							<div className='flex-1'>
+								<DialogTitle className='text-text text-base font-semibold'>
+									Override cert requirement?
+								</DialogTitle>
+								<p className='text-light-text mt-2 text-sm'>
+									{pendingOverride?.warning}. Only continue if this cylinder is
+									being borrowed by a certified diver.
+								</p>
+							</div>
+						</div>
+						<div className='mt-6 flex justify-end gap-2'>
+							<Button variant='ghost' onClick={() => setPendingOverride(null)}>
+								Cancel
+							</Button>
+							<Button onClick={confirmOverride}>Override</Button>
+						</div>
+					</DialogPanel>
+				</div>
+			</Dialog>
 		</div>
 	)
 }

--- a/src/components/Fills/FillsTable.tsx
+++ b/src/components/Fills/FillsTable.tsx
@@ -2,11 +2,10 @@ import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 import FillsRow from './FillsRow'
 import { addNewFill } from '@/redux/fills/fillsSlice'
 import Button from '../UI/Button'
+import Pagination from '../UI/Pagination'
+import usePagination from '@/hooks/usePagination'
 import { Client } from '@/types/client'
 import { PlusCircleIcon } from '@heroicons/react/24/outline'
-import { useEffect, useState, useTransition } from 'react'
-
-const ROWS_PER_PAGE = 20
 
 type FillsTableProps = {
 	client: Client | null
@@ -14,22 +13,14 @@ type FillsTableProps = {
 
 const FillsTable = ({ client }: FillsTableProps) => {
 	const fills = useAppSelector((state) => state.fills.fills)
-
-	const [page, setPage] = useState(1)
-	const [, startTransition] = useTransition()
-
 	const dispatch = useAppDispatch()
 
-	const start = (page - 1) * ROWS_PER_PAGE
-	const end = start + ROWS_PER_PAGE
-	const paginatedFills = fills.slice(start, end)
-	const totalPages = Math.ceil(fills.length / ROWS_PER_PAGE)
-
-	useEffect(() => {
-		startTransition(() => {
-			setPage(1)
-		})
-	}, [fills.length])
+	const {
+		page,
+		setPage,
+		totalPages,
+		paginatedItems: paginatedFills,
+	} = usePagination(fills)
 
 	return (
 		<div className='w-full px-4 sm:px-6 lg:px-8'>
@@ -106,29 +97,11 @@ const FillsTable = ({ client }: FillsTableProps) => {
 									</tr>
 								</tbody>
 							</table>
-							<div className='flex items-center justify-between px-4 py-4'>
-								<p className='text-light-text text-sm'>
-									Page {page} of {totalPages}
-								</p>
-
-								<div className='flex gap-2'>
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.max(p - 1, 1))}
-										disabled={page === 1}
-									>
-										Previous
-									</Button>
-
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
-										disabled={page >= totalPages}
-									>
-										Next
-									</Button>
-								</div>
-							</div>
+							<Pagination
+								page={page}
+								totalPages={totalPages}
+								onPageChange={setPage}
+							/>
 						</div>
 					</div>
 				</div>

--- a/src/components/History/CylindersTab.tsx
+++ b/src/components/History/CylindersTab.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import dayjs from 'dayjs'
+import { Cylinder } from '@/types/cylinder'
+import { Client } from '@/types/client'
+import CylinderListTable from '@/components/Cylinders/CylinderListTable'
+import TableToolbar, { FilterChip } from '@/components/UI/TableToolbar'
+import ListBox from '@/components/UI/FormElements/ListBox'
+import ClientPicker from '@/components/UI/FormElements/ClientPicker'
+import useTableFilters from '@/hooks/useTableFilters'
+import {
+	CYLINDER_SORT_OPTIONS,
+	YES_NO_ANY_OPTIONS,
+} from '@/app/constants/FormConstants'
+
+type CylindersTabProps = {
+	cylinders: Cylinder[]
+}
+
+type TriState = 'any' | 'yes' | 'no'
+
+const matchTri = (state: TriState, actual: boolean): boolean => {
+	if (state === 'any') return true
+	return state === 'yes' ? actual : !actual
+}
+
+const sortByValue: Record<string, (a: Cylinder, b: Cylinder) => number> = {
+	'serial-asc': (a, b) =>
+		(a.nickname ?? a.serialNumber).localeCompare(b.nickname ?? b.serialNumber),
+	'lastVis-asc': (a, b) =>
+		dayjs(a.lastVis).valueOf() - dayjs(b.lastVis).valueOf(),
+	'lastVis-desc': (a, b) =>
+		dayjs(b.lastVis).valueOf() - dayjs(a.lastVis).valueOf(),
+	'lastHydro-asc': (a, b) =>
+		dayjs(a.lastHydro).valueOf() - dayjs(b.lastHydro).valueOf(),
+	'lastHydro-desc': (a, b) =>
+		dayjs(b.lastHydro).valueOf() - dayjs(a.lastHydro).valueOf(),
+}
+
+const triItem = (state: TriState) =>
+	YES_NO_ANY_OPTIONS.find((o) => o.value === state) ?? YES_NO_ANY_OPTIONS[0]
+
+const CylindersTab = ({ cylinders }: CylindersTabProps) => {
+	const [oxygen, setOxygen] = useState<TriState>('any')
+	const [needsVis, setNeedsVis] = useState<TriState>('any')
+	const [outOfHydro, setOutOfHydro] = useState<TriState>('any')
+	const [owner, setOwner] = useState<Client | null>(null)
+	const [sortValue, setSortValue] = useState<string>('serial-asc')
+
+	const predicates = useMemo(() => {
+		const now = dayjs()
+		const list: Array<(c: Cylinder) => boolean> = []
+		if (oxygen !== 'any') {
+			list.push((c) => matchTri(oxygen, c.oxygenClean))
+		}
+		if (needsVis !== 'any') {
+			list.push((c) =>
+				matchTri(needsVis, dayjs(c.lastVis).add(1, 'year').isBefore(now)),
+			)
+		}
+		if (outOfHydro !== 'any') {
+			list.push((c) =>
+				matchTri(outOfHydro, dayjs(c.lastHydro).add(5, 'year').isBefore(now)),
+			)
+		}
+		if (owner) {
+			list.push((c) => c.ownerId === owner.id)
+		}
+		return list
+	}, [oxygen, needsVis, outOfHydro, owner])
+
+	const sort = sortByValue[sortValue]
+	const filtered = useTableFilters(cylinders, { predicates, sort })
+
+	const chips: FilterChip[] = []
+	if (oxygen !== 'any')
+		chips.push({
+			label: `Oxygen clean: ${oxygen === 'yes' ? 'Yes' : 'No'}`,
+			onClear: () => setOxygen('any'),
+		})
+	if (needsVis !== 'any')
+		chips.push({
+			label: needsVis === 'yes' ? 'Needs vis' : 'Vis current',
+			onClear: () => setNeedsVis('any'),
+		})
+	if (outOfHydro !== 'any')
+		chips.push({
+			label: outOfHydro === 'yes' ? 'Out of hydro' : 'Hydro current',
+			onClear: () => setOutOfHydro('any'),
+		})
+	if (owner)
+		chips.push({ label: `Owner: ${owner.name}`, onClear: () => setOwner(null) })
+
+	const clearAll = () => {
+		setOxygen('any')
+		setNeedsVis('any')
+		setOutOfHydro('any')
+		setOwner(null)
+	}
+
+	return (
+		<div className='w-full'>
+			<TableToolbar
+				filters={
+					<>
+						<div className='w-40'>
+							<ListBox
+								items={YES_NO_ANY_OPTIONS}
+								title='Oxygen clean'
+								id='filter-oxygen'
+								name='filter-oxygen'
+								value={triItem(oxygen)}
+								onChange={(item) => setOxygen(item.value as TriState)}
+							/>
+						</div>
+						<div className='w-40'>
+							<ListBox
+								items={YES_NO_ANY_OPTIONS}
+								title='Needs vis'
+								id='filter-needs-vis'
+								name='filter-needs-vis'
+								value={triItem(needsVis)}
+								onChange={(item) => setNeedsVis(item.value as TriState)}
+							/>
+						</div>
+						<div className='w-40'>
+							<ListBox
+								items={YES_NO_ANY_OPTIONS}
+								title='Out of hydro'
+								id='filter-out-hydro'
+								name='filter-out-hydro'
+								value={triItem(outOfHydro)}
+								onChange={(item) => setOutOfHydro(item.value as TriState)}
+							/>
+						</div>
+						<div className='w-60'>
+							<ClientPicker disableAdd value={owner} onChange={setOwner} />
+						</div>
+					</>
+				}
+				sort={
+					<div className='w-60'>
+						<ListBox
+							items={CYLINDER_SORT_OPTIONS}
+							title='Sort by'
+							id='cylinder-sort'
+							name='cylinder-sort'
+							value={
+								CYLINDER_SORT_OPTIONS.find((o) => o.value === sortValue) ??
+								CYLINDER_SORT_OPTIONS[0]
+							}
+							onChange={(item) => setSortValue(item.value)}
+						/>
+					</div>
+				}
+				chips={chips}
+				onClearAll={chips.length > 0 ? clearAll : undefined}
+			/>
+			<CylinderListTable cylinders={filtered} showOwner />
+		</div>
+	)
+}
+
+export default CylindersTab

--- a/src/components/History/FillsTab.tsx
+++ b/src/components/History/FillsTab.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import dayjs from 'dayjs'
+import { FillHistory } from '@/types/fills'
+import { Cylinder } from '@/types/cylinder'
+import { Client } from '@/types/client'
+import FillHistoryTable from '@/components/History/components/FillHistoryTable'
+import TableToolbar, { FilterChip } from '@/components/UI/TableToolbar'
+import ListBox from '@/components/UI/FormElements/ListBox'
+import ClientPicker from '@/components/UI/FormElements/ClientPicker'
+import CylinderPicker from '@/components/UI/FormElements/CylinderPicker'
+import useLoadFills from '@/hooks/useLoadFills'
+import useTableFilters from '@/hooks/useTableFilters'
+import { getFillCategory, FillMixCategory } from '@/lib/fills'
+import {
+	FILL_SORT_OPTIONS,
+	MIX_TYPE_OPTIONS,
+} from '@/app/constants/FormConstants'
+
+type MixFilter = 'any' | FillMixCategory
+
+const sortByValue: Record<string, (a: FillHistory, b: FillHistory) => number> =
+	{
+		'date-desc': (a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf(),
+		'date-asc': (a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf(),
+		'mix-asc': (a, b) => getFillCategory(a).localeCompare(getFillCategory(b)),
+	}
+
+const mixItem = (mix: MixFilter) =>
+	MIX_TYPE_OPTIONS.find((o) => o.value === mix) ?? MIX_TYPE_OPTIONS[0]
+
+const FillsTab = () => {
+	const { fills } = useLoadFills()
+	const [mix, setMix] = useState<MixFilter>('any')
+	const [cylinder, setCylinder] = useState<Cylinder | null>(null)
+	const [owner, setOwner] = useState<Client | null>(null)
+	const [sortValue, setSortValue] = useState<string>('date-desc')
+
+	const predicates = useMemo(() => {
+		const list: Array<(f: FillHistory) => boolean> = []
+		if (mix !== 'any') {
+			list.push((f) => getFillCategory(f) === mix)
+		}
+		if (cylinder) {
+			list.push((f) => f.Cylinder.id === cylinder.id)
+		}
+		if (owner) {
+			list.push((f) => f.Cylinder.Client?.id === owner.id)
+		}
+		return list
+	}, [mix, cylinder, owner])
+
+	const sort = sortByValue[sortValue]
+	const filtered = useTableFilters(fills, { predicates, sort })
+
+	const chips: FilterChip[] = []
+	if (mix !== 'any')
+		chips.push({
+			label: `Mix: ${mix[0].toUpperCase()}${mix.slice(1)}`,
+			onClear: () => setMix('any'),
+		})
+	if (cylinder)
+		chips.push({
+			label: `Cylinder: ${cylinder.nickname ?? cylinder.serialNumber}`,
+			onClear: () => setCylinder(null),
+		})
+	if (owner)
+		chips.push({
+			label: `Owner: ${owner.name}`,
+			onClear: () => setOwner(null),
+		})
+
+	const clearAll = () => {
+		setMix('any')
+		setCylinder(null)
+		setOwner(null)
+	}
+
+	return (
+		<div className='w-full'>
+			<TableToolbar
+				filters={
+					<>
+						<div className='w-40'>
+							<ListBox
+								items={MIX_TYPE_OPTIONS}
+								title='Mix type'
+								id='filter-mix'
+								name='filter-mix'
+								value={mixItem(mix)}
+								onChange={(item) => setMix(item.value as MixFilter)}
+							/>
+						</div>
+						<div className='w-60'>
+							<CylinderPicker
+								value={cylinder}
+								onChange={(c) => setCylinder(c ?? null)}
+							/>
+						</div>
+						<div className='w-60'>
+							<ClientPicker disableAdd value={owner} onChange={setOwner} />
+						</div>
+					</>
+				}
+				sort={
+					<div className='w-60'>
+						<ListBox
+							items={FILL_SORT_OPTIONS}
+							title='Sort by'
+							id='fill-sort'
+							name='fill-sort'
+							value={
+								FILL_SORT_OPTIONS.find((o) => o.value === sortValue) ??
+								FILL_SORT_OPTIONS[0]
+							}
+							onChange={(item) => setSortValue(item.value)}
+						/>
+					</div>
+				}
+				chips={chips}
+				onClearAll={chips.length > 0 ? clearAll : undefined}
+			/>
+			<FillHistoryTable fills={filtered} />
+		</div>
+	)
+}
+
+export default FillsTab

--- a/src/components/History/FillsTab.tsx
+++ b/src/components/History/FillsTab.tsx
@@ -94,6 +94,8 @@ const FillsTab = () => {
 						</div>
 						<div className='w-60'>
 							<CylinderPicker
+								disableAdd
+								filter={() => true}
 								value={cylinder}
 								onChange={(c) => setCylinder(c ?? null)}
 							/>

--- a/src/components/History/MaintenanceHistory/MaintenanceHistory.tsx
+++ b/src/components/History/MaintenanceHistory/MaintenanceHistory.tsx
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs'
 import clsx from 'clsx'
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { useAppDispatch } from '@/redux/hooks'
 import { updateAddServiceModalOpen } from '@/redux/modal/modalSlice'
@@ -11,9 +13,11 @@ import {
 	PlayIcon,
 	WrenchIcon,
 } from '@heroicons/react/20/solid'
-import { MAINTENANCE_TYPE } from '@/types/maintenance'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
+import { CompressorMaintenance, MAINTENANCE_TYPE } from '@/types/maintenance'
 import Button from '@/components/UI/Button'
 import Tooltip from '@/components/UI/Tooltip'
+import EditMaintenanceModal from '@/components/Modals/EditMaintenanceModal'
 import {
 	useLoadMaintenance,
 	useLoadMaintenanceSummary,
@@ -23,6 +27,9 @@ dayjs.extend(relativeTime)
 const MaintenanceHistory = () => {
 	const { maintenance } = useLoadMaintenance()
 	const { summary } = useLoadMaintenanceSummary()
+	const { data: session } = useSession()
+	const isAdmin = session?.user?.role === 'admin'
+	const [editing, setEditing] = useState<CompressorMaintenance | null>(null)
 
 	const dispatch = useAppDispatch()
 	const getColor = (type: MAINTENANCE_TYPE) => {
@@ -169,13 +176,23 @@ const MaintenanceHistory = () => {
 												{event.description}
 											</p>
 										</div>
-										<div className='text-light-text text-right text-sm whitespace-nowrap'>
-											<time dateTime={event.date.format('DD/MM/YYYY')}>
-												{event.date.format('DD/MM/YYYY')}
-											</time>
-											<p className='text-light-text text-sm'>
-												{event.hours} hours
-											</p>
+										<div className='text-light-text flex items-center gap-2 text-right text-sm whitespace-nowrap'>
+											<div>
+												<time dateTime={event.date.format('DD/MM/YYYY')}>
+													{event.date.format('DD/MM/YYYY')}
+												</time>
+												<p className='text-light-text text-sm'>
+													{event.hours} hours
+												</p>
+											</div>
+											{isAdmin && (
+												<Button
+													variant='ghost'
+													onClick={() => setEditing(event)}
+												>
+													<PencilSquareIcon className='h-5 w-5' />
+												</Button>
+											)}
 										</div>
 									</div>
 								</div>
@@ -183,6 +200,12 @@ const MaintenanceHistory = () => {
 						</li>
 					))}
 			</ul>
+			{isAdmin && (
+				<EditMaintenanceModal
+					record={editing}
+					onClose={() => setEditing(null)}
+				/>
+			)}
 		</div>
 	)
 }

--- a/src/components/History/components/ClientListTable.tsx
+++ b/src/components/History/components/ClientListTable.tsx
@@ -20,13 +20,13 @@ const ClientListTable = () => {
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'
 									>
 										Highest Certification
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'
 									>
 										Details
 									</th>

--- a/src/components/History/components/ClientsRow.tsx
+++ b/src/components/History/components/ClientsRow.tsx
@@ -29,10 +29,10 @@ const ClientsRow = ({ client }: { client: Client }) => {
 			<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
 				{client.name}
 			</td>
-			<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
+			<td className='text-text hidden py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:table-cell sm:pl-6'>
 				{clientCert(client)}
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap sm:table-cell'>
 				<Link href={`/clients/${client.id}`}>
 					<LinkIcon className='h-5' />
 				</Link>

--- a/src/components/History/components/FillHistoryRow.tsx
+++ b/src/components/History/components/FillHistoryRow.tsx
@@ -20,10 +20,10 @@ const FillHistoryRow = ({ fill }: { fill: FillHistory }) => {
 			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
 				{getFillMix(fill)}
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap sm:table-cell'>
 				{fill.startPressure}
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap sm:table-cell'>
 				{fill.endPressure}
 			</td>
 			<td className='py-4 pr-4 pl-3 text-center text-sm font-medium whitespace-nowrap sm:pr-6'>

--- a/src/components/History/components/FillHistoryRow.tsx
+++ b/src/components/History/components/FillHistoryRow.tsx
@@ -1,5 +1,6 @@
 import { FillHistory } from '@/types/fills'
 import dayjs from 'dayjs'
+import Tooltip from '@/components/UI/Tooltip'
 
 function getFillMix(fill: FillHistory): string {
 	if (fill.helium != 0) {
@@ -11,6 +12,18 @@ function getFillMix(fill: FillHistory): string {
 	}
 }
 const FillHistoryRow = ({ fill }: { fill: FillHistory }) => {
+	const ownerName = fill.Cylinder.Client?.name
+	const cylinderCell = fill.Cylinder.nickname ? (
+		<div className='flex flex-col items-center'>
+			<span>{fill.Cylinder.nickname}</span>
+			<span className='text-light-text text-xs'>
+				{fill.Cylinder.serialNumber}
+			</span>
+		</div>
+	) : (
+		<span>{fill.Cylinder.serialNumber}</span>
+	)
+
 	return (
 		<tr key={fill.id} className='hover:bg-hover'>
 			<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
@@ -27,15 +40,10 @@ const FillHistoryRow = ({ fill }: { fill: FillHistory }) => {
 				{fill.endPressure}
 			</td>
 			<td className='py-4 pr-4 pl-3 text-center text-sm font-medium whitespace-nowrap sm:pr-6'>
-				{fill.Cylinder.nickname ? (
-					<div className='flex flex-col items-center'>
-						<span>{fill.Cylinder.nickname}</span>
-						<span className='text-light-text text-xs'>
-							{fill.Cylinder.serialNumber}
-						</span>
-					</div>
+				{ownerName ? (
+					<Tooltip message={`Owner: ${ownerName}`}>{cylinderCell}</Tooltip>
 				) : (
-					fill.Cylinder.serialNumber
+					cylinderCell
 				)}
 			</td>
 		</tr>

--- a/src/components/History/components/FillHistoryRow.tsx
+++ b/src/components/History/components/FillHistoryRow.tsx
@@ -2,8 +2,15 @@ import { FillHistory } from '@/types/fills'
 import { getFillMix } from '@/lib/fills'
 import dayjs from 'dayjs'
 import Tooltip from '@/components/UI/Tooltip'
+import Button from '@/components/UI/Button'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
 
-const FillHistoryRow = ({ fill }: { fill: FillHistory }) => {
+type FillHistoryRowProps = {
+	fill: FillHistory
+	onEdit?: () => void
+}
+
+const FillHistoryRow = ({ fill, onEdit }: FillHistoryRowProps) => {
 	const ownerName = fill.Cylinder.Client?.name
 	const cylinderCell = fill.Cylinder.nickname ? (
 		<div className='flex flex-col items-center'>
@@ -38,6 +45,13 @@ const FillHistoryRow = ({ fill }: { fill: FillHistory }) => {
 					cylinderCell
 				)}
 			</td>
+			{onEdit && (
+				<td className='px-3 py-4 text-center text-sm whitespace-nowrap'>
+					<Button variant='ghost' onClick={onEdit}>
+						<PencilSquareIcon className='h-5 w-5' />
+					</Button>
+				</td>
+			)}
 		</tr>
 	)
 }

--- a/src/components/History/components/FillHistoryRow.tsx
+++ b/src/components/History/components/FillHistoryRow.tsx
@@ -1,16 +1,8 @@
 import { FillHistory } from '@/types/fills'
+import { getFillMix } from '@/lib/fills'
 import dayjs from 'dayjs'
 import Tooltip from '@/components/UI/Tooltip'
 
-function getFillMix(fill: FillHistory): string {
-	if (fill.helium != 0) {
-		return `${fill.oxygen}/${fill.helium}`
-	} else if (fill.oxygen == 20.9) {
-		return 'air'
-	} else {
-		return `EAN ${fill.oxygen}`
-	}
-}
 const FillHistoryRow = ({ fill }: { fill: FillHistory }) => {
 	const ownerName = fill.Cylinder.Client?.name
 	const cylinderCell = fill.Cylinder.nickname ? (

--- a/src/components/History/components/FillHistoryTable.tsx
+++ b/src/components/History/components/FillHistoryTable.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import FillHistoryRow from './FillHistoryRow'
-import { useEffect, useState, useTransition } from 'react'
-import Button from '@/components/UI/Button'
+import Pagination from '@/components/UI/Pagination'
+import usePagination from '@/hooks/usePagination'
 import useLoadFills from '@/hooks/useLoadFills'
 import { FillHistory } from '@/types/fills'
-
-const ROWS_PER_PAGE = 20
 
 type FillHistoryTableProps = {
 	fills?: FillHistory[]
@@ -16,19 +14,12 @@ const FillHistoryTable = ({ fills: propFills }: FillHistoryTableProps = {}) => {
 	const { fills: hookFills } = useLoadFills({ enabled: !propFills })
 	const fills = propFills ?? hookFills
 
-	const [page, setPage] = useState(1)
-	const [, startTransition] = useTransition()
-
-	const start = (page - 1) * ROWS_PER_PAGE
-	const end = start + ROWS_PER_PAGE
-	const paginatedFills = fills.slice(start, end)
-	const totalPages = Math.ceil(fills.length / ROWS_PER_PAGE)
-
-	useEffect(() => {
-		startTransition(() => {
-			setPage(1)
-		})
-	}, [fills.length])
+	const {
+		page,
+		setPage,
+		totalPages,
+		paginatedItems: paginatedFills,
+	} = usePagination(fills)
 
 	return (
 		<div className='min-w-full'>
@@ -77,29 +68,11 @@ const FillHistoryTable = ({ fills: propFills }: FillHistoryTableProps = {}) => {
 									))}
 								</tbody>
 							</table>
-							<div className='flex items-center justify-between px-4 py-4'>
-								<p className='text-light-text text-sm'>
-									Page {page} of {totalPages}
-								</p>
-
-								<div className='flex gap-2'>
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.max(p - 1, 1))}
-										disabled={page === 1}
-									>
-										Previous
-									</Button>
-
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
-										disabled={page >= totalPages}
-									>
-										Next
-									</Button>
-								</div>
-							</div>
+							<Pagination
+								page={page}
+								totalPages={totalPages}
+								onPageChange={setPage}
+							/>
 						</div>
 					</div>
 				</div>

--- a/src/components/History/components/FillHistoryTable.tsx
+++ b/src/components/History/components/FillHistoryTable.tsx
@@ -53,13 +53,13 @@ const FillHistoryTable = ({ fills: propFills }: FillHistoryTableProps = {}) => {
 										</th>
 										<th
 											scope='col'
-											className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+											className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'
 										>
 											Start Pressure
 										</th>
 										<th
 											scope='col'
-											className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+											className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'
 										>
 											End Pressure
 										</th>

--- a/src/components/History/components/FillHistoryTable.tsx
+++ b/src/components/History/components/FillHistoryTable.tsx
@@ -1,6 +1,9 @@
 'use client'
 
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
 import FillHistoryRow from './FillHistoryRow'
+import EditFillModal from '@/components/Modals/EditFillModal'
 import Pagination from '@/components/UI/Pagination'
 import usePagination from '@/hooks/usePagination'
 import useLoadFills from '@/hooks/useLoadFills'
@@ -13,6 +16,9 @@ type FillHistoryTableProps = {
 const FillHistoryTable = ({ fills: propFills }: FillHistoryTableProps = {}) => {
 	const { fills: hookFills } = useLoadFills({ enabled: !propFills })
 	const fills = propFills ?? hookFills
+	const { data: session } = useSession()
+	const isAdmin = session?.user?.role === 'admin'
+	const [editing, setEditing] = useState<FillHistory | null>(null)
 
 	const {
 		page,
@@ -60,11 +66,23 @@ const FillHistoryTable = ({ fills: propFills }: FillHistoryTableProps = {}) => {
 										>
 											Cylinder
 										</th>
+										{isAdmin && (
+											<th
+												scope='col'
+												className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+											>
+												<span className='sr-only'>Edit</span>
+											</th>
+										)}
 									</tr>
 								</thead>
 								<tbody className='bg-background divide-divider divide-y'>
 									{paginatedFills.map((fill) => (
-										<FillHistoryRow key={fill.id} fill={fill} />
+										<FillHistoryRow
+											key={fill.id}
+											fill={fill}
+											onEdit={isAdmin ? () => setEditing(fill) : undefined}
+										/>
 									))}
 								</tbody>
 							</table>
@@ -77,6 +95,9 @@ const FillHistoryTable = ({ fills: propFills }: FillHistoryTableProps = {}) => {
 					</div>
 				</div>
 			</div>
+			{isAdmin && (
+				<EditFillModal fill={editing} onClose={() => setEditing(null)} />
+			)}
 		</div>
 	)
 }

--- a/src/components/History/components/VisHistoryRow.tsx
+++ b/src/components/History/components/VisHistoryRow.tsx
@@ -40,7 +40,7 @@ const VisHistoryRow = ({
 					)}
 				</span>
 			</td>
-			<td className='text-light-text px-3 py-4 text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-sm whitespace-nowrap sm:table-cell'>
 				<span className='flex w-full justify-center'>
 					{visual.markedOxygenClean ? (
 						<CheckCircleIcon className='h-10' />

--- a/src/components/History/components/VisHistoryTable.tsx
+++ b/src/components/History/components/VisHistoryTable.tsx
@@ -62,7 +62,7 @@ const VisHistoryTable = ({
 										</th>
 										<th
 											scope='col'
-											className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+											className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'
 										>
 											Oxygen Clean
 										</th>

--- a/src/components/History/components/VisHistoryTable.tsx
+++ b/src/components/History/components/VisHistoryTable.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import VisHistoryRow from './VisHistoryRow'
-import { useEffect, useState, useTransition } from 'react'
-import Button from '@/components/UI/Button'
+import Pagination from '@/components/UI/Pagination'
+import usePagination from '@/hooks/usePagination'
 import useLoadVisuals from '@/hooks/useLoadVisuals'
 import { VisualHistory } from '@/types/visuals'
-
-const ROWS_PER_PAGE = 20
 
 type VisHistoryTableProps = {
 	visuals?: VisualHistory[]
@@ -19,19 +17,12 @@ const VisHistoryTable = ({
 }: VisHistoryTableProps = {}) => {
 	const { visuals: hookVisuals } = useLoadVisuals({ enabled: !propVisuals })
 	const visuals = propVisuals ?? hookVisuals
-	const [page, setPage] = useState(1)
-	const [, startTransition] = useTransition()
-
-	const start = (page - 1) * ROWS_PER_PAGE
-	const end = start + ROWS_PER_PAGE
-	const paginatedVisuals = visuals.slice(start, end)
-	const totalPages = Math.ceil(visuals.length / ROWS_PER_PAGE)
-
-	useEffect(() => {
-		startTransition(() => {
-			setPage(1)
-		})
-	}, [visuals.length])
+	const {
+		page,
+		setPage,
+		totalPages,
+		paginatedItems: paginatedVisuals,
+	} = usePagination(visuals)
 
 	return (
 		<div className='min-w-full'>
@@ -86,29 +77,11 @@ const VisHistoryTable = ({
 									))}
 								</tbody>
 							</table>
-							<div className='flex items-center justify-between px-4 py-4'>
-								<p className='text-light-text text-sm'>
-									Page {page} of {totalPages}
-								</p>
-
-								<div className='flex gap-2'>
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.max(p - 1, 1))}
-										disabled={page === 1}
-									>
-										Previous
-									</Button>
-
-									<Button
-										variant='ghost'
-										onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
-										disabled={page >= totalPages}
-									>
-										Next
-									</Button>
-								</div>
-							</div>
+							<Pagination
+								page={page}
+								totalPages={totalPages}
+								onPageChange={setPage}
+							/>
 						</div>
 					</div>
 				</div>

--- a/src/components/Modals/EditFillModal.tsx
+++ b/src/components/Modals/EditFillModal.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import {
+	Dialog,
+	DialogPanel,
+	DialogTitle,
+	Transition,
+	TransitionChild,
+} from '@headlessui/react'
+import { Fragment, useState } from 'react'
+import dayjs, { Dayjs } from 'dayjs'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'react-toastify'
+import Button from '../UI/Button'
+import DatePicker from '../UI/FormElements/DatePicker'
+import NumberInput from '../UI/FormElements/NumberInput'
+import { updateFill } from '@/app/_api'
+import { FillHistory } from '@/types/fills'
+
+type EditFillModalProps = {
+	fill: FillHistory | null
+	onClose: () => void
+}
+
+const EditFillModal = ({ fill, onClose }: EditFillModalProps) => {
+	const queryClient = useQueryClient()
+	const [date, setDate] = useState<Dayjs>(fill ? dayjs(fill.date) : dayjs())
+	const [start, setStart] = useState(fill?.startPressure ?? 0)
+	const [end, setEnd] = useState(fill?.endPressure ?? 0)
+	const [oxygen, setOxygen] = useState(fill?.oxygen ?? 20.9)
+	const [helium, setHelium] = useState(fill?.helium ?? 0)
+	const [saving, setSaving] = useState(false)
+
+	const handleSave = async () => {
+		if (!fill) return
+		setSaving(true)
+		const result = await updateFill(fill.id, {
+			date: date.toISOString(),
+			startPressure: start,
+			endPressure: end,
+			oxygen,
+			helium,
+		})
+		setSaving(false)
+		if (typeof result === 'string') {
+			toast.error(`Failed to update fill: ${result}`)
+			return
+		}
+		toast.success('Fill updated')
+		queryClient.invalidateQueries({ queryKey: ['fills'] })
+		onClose()
+	}
+
+	return (
+		<Transition show={fill !== null} as={Fragment}>
+			<Dialog
+				as='div'
+				key={fill?.id}
+				onClose={onClose}
+				className='relative z-50'
+			>
+				<TransitionChild
+					as={Fragment}
+					enter='ease-out duration-200'
+					enterFrom='opacity-0'
+					enterTo='opacity-100'
+					leave='ease-in duration-150'
+					leaveFrom='opacity-100'
+					leaveTo='opacity-0'
+				>
+					<div className='fixed inset-0 bg-black/30 transition-opacity' />
+				</TransitionChild>
+				<div className='fixed inset-0 z-50'>
+					<div className='flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0'>
+						<TransitionChild
+							as={Fragment}
+							enter='ease-out duration-200'
+							enterFrom='opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+							enterTo='opacity-100 translate-y-0 sm:scale-100'
+							leave='ease-in duration-150'
+							leaveFrom='opacity-100 translate-y-0 sm:scale-100'
+							leaveTo='opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+						>
+							<DialogPanel className='bg-background w-full max-w-lg rounded-lg p-6 shadow-xl sm:my-8'>
+								<DialogTitle className='text-text text-lg font-semibold'>
+									Edit fill
+								</DialogTitle>
+								<p className='text-light-text mt-1 text-sm'>
+									{fill?.Cylinder?.nickname ?? fill?.Cylinder?.serialNumber}
+								</p>
+
+								<div className='mt-4 flex flex-col gap-4'>
+									<DatePicker
+										title='Fill date'
+										id='edit-fill-date'
+										name='date'
+										value={date}
+										onChange={setDate}
+									/>
+									<div className='grid grid-cols-2 gap-4'>
+										<NumberInput
+											id='edit-fill-start'
+											name='startPressure'
+											label='Start pressure (psi)'
+											value={start}
+											onChange={setStart}
+										/>
+										<NumberInput
+											id='edit-fill-end'
+											name='endPressure'
+											label='End pressure (psi)'
+											value={end}
+											onChange={setEnd}
+										/>
+										<NumberInput
+											id='edit-fill-oxygen'
+											name='oxygen'
+											label='Oxygen %'
+											value={oxygen}
+											onChange={setOxygen}
+										/>
+										<NumberInput
+											id='edit-fill-helium'
+											name='helium'
+											label='Helium %'
+											value={helium}
+											onChange={setHelium}
+										/>
+									</div>
+								</div>
+
+								<div className='mt-6 flex justify-end gap-2'>
+									<Button variant='ghost' onClick={onClose} disabled={saving}>
+										Cancel
+									</Button>
+									<Button onClick={handleSave} disabled={saving}>
+										{saving ? 'Saving…' : 'Save'}
+									</Button>
+								</div>
+							</DialogPanel>
+						</TransitionChild>
+					</div>
+				</div>
+			</Dialog>
+		</Transition>
+	)
+}
+
+export default EditFillModal

--- a/src/components/Modals/EditMaintenanceModal.tsx
+++ b/src/components/Modals/EditMaintenanceModal.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import {
+	Dialog,
+	DialogPanel,
+	DialogTitle,
+	Transition,
+	TransitionChild,
+} from '@headlessui/react'
+import { Fragment, useState } from 'react'
+import dayjs, { Dayjs } from 'dayjs'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'react-toastify'
+import Button from '../UI/Button'
+import DatePicker from '../UI/FormElements/DatePicker'
+import NumberInput from '../UI/FormElements/NumberInput'
+import TextInput from '../UI/FormElements/TextInput'
+import { updateMaintenance } from '@/app/_api'
+import { CompressorMaintenance } from '@/types/maintenance'
+
+type EditMaintenanceModalProps = {
+	record: CompressorMaintenance | null
+	onClose: () => void
+}
+
+const EditMaintenanceModal = ({
+	record,
+	onClose,
+}: EditMaintenanceModalProps) => {
+	const queryClient = useQueryClient()
+	const [date, setDate] = useState<Dayjs>(record ? dayjs(record.date) : dayjs())
+	const [hours, setHours] = useState(record?.hours ?? 0)
+	const [description, setDescription] = useState(record?.description ?? '')
+	const [saving, setSaving] = useState(false)
+
+	const handleSave = async () => {
+		if (!record) return
+		setSaving(true)
+		const result = await updateMaintenance(record.id, {
+			date: date.toISOString(),
+			hours,
+			description,
+		})
+		setSaving(false)
+		if (typeof result === 'string') {
+			toast.error(`Failed to update record: ${result}`)
+			return
+		}
+		toast.success('Maintenance record updated')
+		queryClient.invalidateQueries({ queryKey: ['maintenance'] })
+		queryClient.invalidateQueries({ queryKey: ['maintenance-summary'] })
+		onClose()
+	}
+
+	return (
+		<Transition show={record !== null} as={Fragment}>
+			<Dialog
+				as='div'
+				key={record?.id}
+				onClose={onClose}
+				className='relative z-50'
+			>
+				<TransitionChild
+					as={Fragment}
+					enter='ease-out duration-200'
+					enterFrom='opacity-0'
+					enterTo='opacity-100'
+					leave='ease-in duration-150'
+					leaveFrom='opacity-100'
+					leaveTo='opacity-0'
+				>
+					<div className='fixed inset-0 bg-black/30 transition-opacity' />
+				</TransitionChild>
+				<div className='fixed inset-0 z-50'>
+					<div className='flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0'>
+						<TransitionChild
+							as={Fragment}
+							enter='ease-out duration-200'
+							enterFrom='opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+							enterTo='opacity-100 translate-y-0 sm:scale-100'
+							leave='ease-in duration-150'
+							leaveFrom='opacity-100 translate-y-0 sm:scale-100'
+							leaveTo='opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+						>
+							<DialogPanel className='bg-background w-full max-w-lg rounded-lg p-6 shadow-xl sm:my-8'>
+								<DialogTitle className='text-text text-lg font-semibold'>
+									Edit maintenance record
+								</DialogTitle>
+
+								<div className='mt-4 flex flex-col gap-4'>
+									<DatePicker
+										title='Service date'
+										id='edit-maintenance-date'
+										name='date'
+										value={date}
+										onChange={setDate}
+									/>
+									<NumberInput
+										id='edit-maintenance-hours'
+										name='hours'
+										label='Compressor hours'
+										value={hours}
+										onChange={setHours}
+									/>
+									<TextInput
+										id='edit-maintenance-description'
+										name='description'
+										type='text'
+										ariaLabel='Description'
+										placeholder='Description'
+										value={description}
+										onChange={(e) => setDescription(e.target.value)}
+									/>
+								</div>
+
+								<div className='mt-6 flex justify-end gap-2'>
+									<Button variant='ghost' onClick={onClose} disabled={saving}>
+										Cancel
+									</Button>
+									<Button onClick={handleSave} disabled={saving}>
+										{saving ? 'Saving…' : 'Save'}
+									</Button>
+								</div>
+							</DialogPanel>
+						</TransitionChild>
+					</div>
+				</div>
+			</Dialog>
+		</Transition>
+	)
+}
+
+export default EditMaintenanceModal

--- a/src/components/Settings/AuditLogTable.tsx
+++ b/src/components/Settings/AuditLogTable.tsx
@@ -20,7 +20,7 @@ const AuditLogTable = ({ entries }: { entries: AuditEntry[] }) => {
 									<th className='text-text py-3.5 pr-3 pl-4 text-center text-sm font-semibold sm:pl-6'>
 										Date
 									</th>
-									<th className='text-text px-3 py-3.5 text-center text-sm font-semibold'>
+									<th className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'>
 										User
 									</th>
 									<th className='text-text px-3 py-3.5 text-center text-sm font-semibold'>
@@ -29,7 +29,7 @@ const AuditLogTable = ({ entries }: { entries: AuditEntry[] }) => {
 									<th className='text-text px-3 py-3.5 text-center text-sm font-semibold'>
 										Entity
 									</th>
-									<th className='text-text px-3 py-3.5 text-center text-sm font-semibold'>
+									<th className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold md:table-cell'>
 										Entity ID
 									</th>
 								</tr>
@@ -40,7 +40,7 @@ const AuditLogTable = ({ entries }: { entries: AuditEntry[] }) => {
 										<td className='text-light-text py-4 pr-3 pl-4 text-center text-sm sm:pl-6'>
 											{new Date(entry.createdAt).toLocaleString()}
 										</td>
-										<td className='text-light-text px-3 py-4 text-center text-sm'>
+										<td className='text-light-text hidden px-3 py-4 text-center text-sm sm:table-cell'>
 											{entry.user?.name ?? entry.user?.email ?? '—'}
 										</td>
 										<td className='text-text px-3 py-4 text-center text-sm font-medium'>
@@ -49,7 +49,7 @@ const AuditLogTable = ({ entries }: { entries: AuditEntry[] }) => {
 										<td className='text-light-text px-3 py-4 text-center text-sm'>
 											{entry.entity}
 										</td>
-										<td className='text-light-text px-3 py-4 text-center text-sm'>
+										<td className='text-light-text hidden px-3 py-4 text-center text-sm md:table-cell'>
 											{entry.entityId}
 										</td>
 									</tr>

--- a/src/components/Settings/UserListTable.tsx
+++ b/src/components/Settings/UserListTable.tsx
@@ -18,7 +18,7 @@ const UserListTable = ({ users }: { users: Profile[] }) => {
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold sm:table-cell'
 									>
 										Email
 									</th>
@@ -30,13 +30,13 @@ const UserListTable = ({ users }: { users: Profile[] }) => {
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold lg:table-cell'
 									>
 										Last Login
 									</th>
 									<th
 										scope='col'
-										className='text-text px-3 py-3.5 text-center text-sm font-semibold'
+										className='text-text hidden px-3 py-3.5 text-center text-sm font-semibold md:table-cell'
 									>
 										Linked Client
 									</th>

--- a/src/components/Settings/UserRow.tsx
+++ b/src/components/Settings/UserRow.tsx
@@ -48,7 +48,7 @@ const UserRow = ({ user }: { user: Profile }) => {
 			<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
 				{user.name ?? '—'}
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap sm:table-cell'>
 				{user.email ?? '—'}
 			</td>
 			<td className='px-3 py-4 text-center text-sm whitespace-nowrap'>
@@ -61,7 +61,7 @@ const UserRow = ({ user }: { user: Profile }) => {
 					onChange={handleRoleChange}
 				/>
 			</td>
-			<td className='text-light-text px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='text-light-text hidden px-3 py-4 text-center text-sm whitespace-nowrap lg:table-cell'>
 				{user.lastLogin ? (
 					<Tooltip message={dayjs(user.lastLogin).format('MMM D, YYYY h:mm A')}>
 						{dayjs(user.lastLogin).fromNow()}
@@ -70,7 +70,7 @@ const UserRow = ({ user }: { user: Profile }) => {
 					'Never'
 				)}
 			</td>
-			<td className='px-3 py-4 text-center text-sm whitespace-nowrap'>
+			<td className='hidden px-3 py-4 text-center text-sm whitespace-nowrap md:table-cell'>
 				<ClientPicker
 					disableAdd
 					value={selectedClient}

--- a/src/components/UI/FormElements/CylinderPicker.tsx
+++ b/src/components/UI/FormElements/CylinderPicker.tsx
@@ -34,6 +34,7 @@ type CylinderPickerProps = {
 	disableAdd?: boolean
 	showExpired?: boolean
 	initialValue?: Cylinder
+	value?: Cylinder | null
 	filter?: (c: Cylinder) => boolean
 	onChange?: (c?: Cylinder) => void
 	visPage?: boolean
@@ -46,6 +47,7 @@ const CylinderPicker = ({
 	showExpired = false,
 	filter,
 	initialValue,
+	value,
 	onChange,
 	visPage,
 }: CylinderPickerProps) => {
@@ -56,6 +58,9 @@ const CylinderPicker = ({
 	const [selectedCylinder, setSelectedCylinder] = useState<
 		Cylinder | null | undefined
 	>(initialValue)
+
+	const isControlled = value !== undefined
+	const currentValue = isControlled ? value : selectedCylinder
 
 	const filteredCylinders =
 		query === ''
@@ -83,15 +88,15 @@ const CylinderPicker = ({
 	return (
 		<Combobox
 			as='div'
-			value={selectedCylinder}
+			value={currentValue}
 			onChange={(cylinder) => {
 				setQuery('')
-				setSelectedCylinder(cylinder)
+				if (!isControlled) setSelectedCylinder(cylinder)
 				if (cylinder) {
 					if (!cylinder.verified) {
 						dispatch(updateEditCylinderModal(cylinder))
 					}
-					onChange && onChange(cylinder)
+					onChange?.(cylinder)
 				}
 			}}
 			className='w-full min-w-[12rem] sm:w-1/2'

--- a/src/components/UI/FormElements/ListBox.tsx
+++ b/src/components/UI/FormElements/ListBox.tsx
@@ -21,6 +21,7 @@ type ListBoxProps = {
 	id: string
 	name: string
 	defaultValue?: Item
+	value?: Item
 	onChange?: (item: Item) => void
 }
 
@@ -30,14 +31,17 @@ const ListBox = ({
 	id,
 	name,
 	defaultValue,
+	value,
 	onChange,
 }: ListBoxProps) => {
-	const [selected, setSelected] = useState<Item | undefined>(
+	const [internal, setInternal] = useState<Item | undefined>(
 		defaultValue || items[0],
 	)
+	const isControlled = value !== undefined
+	const selected = isControlled ? value : internal
 
 	const handleChange = (item: Item) => {
-		setSelected(item)
+		if (!isControlled) setInternal(item)
 		onChange?.(item)
 	}
 

--- a/src/components/UI/Pagination.tsx
+++ b/src/components/UI/Pagination.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Button from './Button'
+
+type PaginationProps = {
+	page: number
+	totalPages: number
+	onPageChange: (page: number) => void
+}
+
+const Pagination = ({ page, totalPages, onPageChange }: PaginationProps) => {
+	if (totalPages <= 1) return null
+
+	return (
+		<div className='flex items-center justify-between px-4 py-4'>
+			<p className='text-light-text text-sm'>
+				Page {page} of {totalPages}
+			</p>
+			<div className='flex gap-2'>
+				<Button
+					variant='ghost'
+					onClick={() => onPageChange(Math.max(page - 1, 1))}
+					disabled={page === 1}
+				>
+					Previous
+				</Button>
+				<Button
+					variant='ghost'
+					onClick={() => onPageChange(Math.min(page + 1, totalPages))}
+					disabled={page >= totalPages}
+				>
+					Next
+				</Button>
+			</div>
+		</div>
+	)
+}
+
+export default Pagination

--- a/src/components/UI/TableToolbar.tsx
+++ b/src/components/UI/TableToolbar.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import Button from './Button'
+
+export type FilterChip = {
+	label: string
+	onClear: () => void
+}
+
+type TableToolbarProps = {
+	filters: ReactNode
+	sort?: ReactNode
+	chips?: FilterChip[]
+	onClearAll?: () => void
+}
+
+const TableToolbar = ({
+	filters,
+	sort,
+	chips = [],
+	onClearAll,
+}: TableToolbarProps) => {
+	const hasChips = chips.length > 0
+	return (
+		<div className='border-border bg-surface mb-4 rounded-lg border p-3'>
+			<div className='flex flex-wrap items-end gap-3'>
+				<div className='flex flex-1 flex-wrap items-end gap-3'>{filters}</div>
+				{sort && <div className='w-full sm:w-auto'>{sort}</div>}
+			</div>
+			{hasChips && (
+				<div className='mt-3 flex flex-wrap items-center gap-2'>
+					{chips.map((chip) => (
+						<button
+							key={chip.label}
+							type='button'
+							onClick={chip.onClear}
+							className='bg-card-hover text-text hover:bg-hover inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium'
+						>
+							<span>{chip.label}</span>
+							<XMarkIcon className='h-3.5 w-3.5' aria-hidden='true' />
+						</button>
+					))}
+					{onClearAll && (
+						<Button variant='ghost' onClick={onClearAll}>
+							Clear all
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default TableToolbar

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useMemo, useState, useTransition } from 'react'
+
+type UsePaginationResult<T> = {
+	page: number
+	setPage: (page: number) => void
+	totalPages: number
+	paginatedItems: T[]
+}
+
+const usePagination = <T,>(
+	items: T[],
+	rowsPerPage = 20,
+): UsePaginationResult<T> => {
+	const [page, setPage] = useState(1)
+	const [, startTransition] = useTransition()
+
+	const totalPages = Math.max(1, Math.ceil(items.length / rowsPerPage))
+
+	useEffect(() => {
+		startTransition(() => {
+			setPage(1)
+		})
+	}, [items.length])
+
+	const paginatedItems = useMemo(() => {
+		const start = (page - 1) * rowsPerPage
+		return items.slice(start, start + rowsPerPage)
+	}, [items, page, rowsPerPage])
+
+	return { page, setPage, totalPages, paginatedItems }
+}
+
+export default usePagination

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useMemo } from 'react'
+
+type UseTableFiltersOptions<T> = {
+	predicates?: Array<(item: T) => boolean>
+	sort?: (a: T, b: T) => number
+}
+
+const useTableFilters = <T,>(
+	items: T[],
+	{ predicates, sort }: UseTableFiltersOptions<T> = {},
+): T[] => {
+	return useMemo(() => {
+		let result = items
+		if (predicates && predicates.length > 0) {
+			result = result.filter((item) => predicates.every((p) => p(item)))
+		}
+		if (sort) {
+			result = [...result].sort(sort)
+		}
+		return result
+	}, [items, predicates, sort])
+}
+
+export default useTableFilters

--- a/src/lib/fills.ts
+++ b/src/lib/fills.ts
@@ -1,0 +1,15 @@
+export type FillMixCategory = 'air' | 'nitrox' | 'trimix'
+
+type MixSource = { oxygen: number; helium: number }
+
+export function getFillCategory(fill: MixSource): FillMixCategory {
+	if (fill.helium > 0) return 'trimix'
+	if (fill.oxygen === 20.9) return 'air'
+	return 'nitrox'
+}
+
+export function getFillMix(fill: MixSource): string {
+	if (fill.helium !== 0) return `${fill.oxygen}/${fill.helium}`
+	if (fill.oxygen === 20.9) return 'air'
+	return `EAN ${fill.oxygen}`
+}

--- a/src/types/cylinder.ts
+++ b/src/types/cylinder.ts
@@ -5,6 +5,7 @@ export type Cylinder = {
 	lastHydro: string | undefined
 	lastVis: string | undefined
 	ownerId?: number
+	Client?: { id: number; name: string } | null
 	servicePressure: number
 	oxygenClean: boolean
 	verified: boolean


### PR DESCRIPTION
- **feat: hide low-priority table columns on small screens**
- **feat: small-screen nav, owner names, and fill-history owner tooltip**
- **refactor: extract shared usePagination hook and Pagination component**
- **docs: spec for table filters & sort (cylinders + fill history)**
- **docs: implementation plan for table filters & sort**
- **refactor: extract fill mix helpers into src/lib/fills**
- **feat: add filter and sort option constants for history tables**
- **feat: support controlled value prop on ListBox and CylinderPicker**
- **feat: add useTableFilters hook**
- **feat: add TableToolbar component for filter + sort controls**
- **feat: add CylindersTab with filter and sort controls**
- **feat: add FillsTab with filter and sort controls**
- **feat: wire filter/sort tabs into history page**
- **fix: render cylinder options in FillsTab dropdown**
- **feat: add fills tab to the client details page**
- **feat: allow operator override of fill cert requirement**
- **feat: admin can edit fills and compressor maintenance entries**
- **chore: gitignore auto-generated next-env.d.ts**
