### PR TITLE
feat/paired cylinders

### DIFF
--- a/docs/superpowers/plans/2026-06-07-paired-cylinders.md
+++ b/docs/superpowers/plans/2026-06-07-paired-cylinders.md
@@ -1,0 +1,904 @@
+# Paired Cylinders (Doubles) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let two cylinders be linked as a persistent pair so a "set of doubles" can be filled in one row — entering pressure/gas once — while still producing one Fill record per cylinder.
+
+**Architecture:** A nullable self-referential `pairedCylinderId` column on the Cylinder model links two cylinders (A↔B). The cylinder edit modal manages the pairing; the PUT route keeps both pointers consistent in a transaction. On the fills page, selecting a paired cylinder carries its partner in the in-progress Redux fill entry; on submit, a paired entry expands into two `FillDto` records with identical values, so the Fill DB schema and POST `/api/fills` are unchanged.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, TypeScript, Redux Toolkit, React Query, Sequelize + MariaDB, Tailwind v4. No test framework is configured — verification is `npm run lint`, `npm run build`, running migrations, and explicit manual checks.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-paired-cylinders-design.md`
+
+---
+
+## File Structure
+
+- `migrations/20260607000001-add-cylinder-paired.cjs` (new) — adds `pairedCylinderId` column + self FK.
+- `src/lib/models/cylinder/index.tsx` — attribute + self-association.
+- `src/types/cylinder.ts` — `pairedCylinderId` / `pairedCylinder` on type + DTO.
+- `src/types/fills.ts` — `pairedCylinder` on in-progress `Fill`.
+- `src/app/api/cylinders/route.tsx` — eager-load partner in GET.
+- `src/app/api/clients/[clientId]/cylinders/route.tsx` — eager-load partner in GET.
+- `src/app/api/cylinders/[cylinderId]/route.tsx` — accept `pairedCylinderId`, bidirectional update in a transaction.
+- `src/components/Modals/CylinderModal.tsx` — pairing picker (edit-only) + clear button.
+- `src/components/Fills/FillsRow.tsx` / `FillCard.tsx` — combined paired row, used-cylinder filter, unlink control.
+- `src/components/Fills/FillType.tsx` — validate gas/cert against both cylinders of a pair.
+- `src/app/fills/page.tsx` — expand paired entries into two `FillDto` on submit.
+- `src/components/Cylinders/CylinderListRow.tsx` — optional "paired" indicator.
+
+---
+
+## Task 1: Database migration + model column
+
+**Files:**
+- Create: `migrations/20260607000001-add-cylinder-paired.cjs`
+- Modify: `src/lib/models/cylinder/index.tsx`
+
+- [ ] **Step 1: Write the migration**
+
+Create `migrations/20260607000001-add-cylinder-paired.cjs`:
+
+```js
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		await queryInterface.addColumn('Cylinders', 'pairedCylinderId', {
+			type: Sequelize.INTEGER.UNSIGNED,
+			allowNull: true,
+			defaultValue: null,
+			references: { model: 'Cylinders', key: 'id' },
+			onUpdate: 'CASCADE',
+			onDelete: 'SET NULL',
+		})
+	},
+
+	async down(queryInterface) {
+		await queryInterface.removeColumn('Cylinders', 'pairedCylinderId')
+	},
+}
+```
+
+- [ ] **Step 2: Run the migration**
+
+Run: `npx sequelize-cli db:migrate`
+Expected: migration `20260607000001-add-cylinder-paired` runs successfully, no errors. (Requires the local MariaDB from `docker compose up` to be running.)
+
+- [ ] **Step 3: Add the attribute and association to the model**
+
+In `src/lib/models/cylinder/index.tsx`, add the attribute declaration after the `size` declaration (line 56):
+
+```ts
+	declare size: CreationOptional<number | null>
+
+	declare pairedCylinderId: CreationOptional<number | null>
+	declare pairedCylinder?: NonAttribute<Cylinder>
+```
+
+In the `Cylinder.init({...})` object, add this column definition after the `size` block (after line 167):
+
+```ts
+		size: {
+			type: DataTypes.FLOAT,
+			allowNull: true,
+			defaultValue: null,
+		},
+		pairedCylinderId: {
+			type: DataTypes.INTEGER.UNSIGNED,
+			allowNull: true,
+			defaultValue: null,
+		},
+```
+
+After the existing associations at the bottom of the file (after line 178), add the self-association:
+
+```ts
+Cylinder.belongsTo(Client, { foreignKey: 'ownerId' })
+Client.hasMany(Cylinder, { foreignKey: 'ownerId' })
+
+Cylinder.belongsTo(Cylinder, {
+	as: 'pairedCylinder',
+	foreignKey: 'pairedCylinderId',
+})
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes (prettier + eslint) with no errors in the edited files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/20260607000001-add-cylinder-paired.cjs src/lib/models/cylinder/index.tsx
+git commit -m "feat: add pairedCylinderId column and self-association to Cylinder"
+```
+
+---
+
+## Task 2: Type updates
+
+**Files:**
+- Modify: `src/types/cylinder.ts`
+
+- [ ] **Step 1: Add fields to the Cylinder type and DTO**
+
+In `src/types/cylinder.ts`, add `pairedCylinderId` and `pairedCylinder` to `Cylinder` (after `size`, line 15), and `pairedCylinderId` to `NewCylinderDTO` (after `size`, line 30). The `pairedCylinder` partner uses a minimal shape (only scalar, non-date fields are eager-loaded by the API):
+
+```ts
+export type Cylinder = {
+	id: number
+	serialNumber: string
+	birth: string | undefined
+	lastHydro: string | undefined
+	lastVis: string | undefined
+	ownerId?: number
+	Client?: { id: number; name: string } | null
+	servicePressure: number
+	oxygenClean: boolean
+	verified: boolean
+	material?: 'steel' | 'aluminum' | 'composite'
+	nickname?: string | null
+	manufacturer?: string | null
+	size?: number | null
+	pairedCylinderId?: number | null
+	pairedCylinder?: {
+		id: number
+		serialNumber: string
+		nickname?: string | null
+		servicePressure: number
+		oxygenClean: boolean
+		ownerId?: number
+	} | null
+	createdAt?: string
+	updatedAt?: string
+}
+
+export type NewCylinderDTO = {
+	serialNumber: string
+	birth: Date
+	lastHydro: Date
+	lastVis: Date
+	servicePressure: number
+	oxygenClean: boolean
+	material?: 'steel' | 'aluminum' | 'composite'
+	nickname?: string
+	manufacturer?: string
+	size?: number
+	pairedCylinderId?: number | null
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/cylinder.ts
+git commit -m "feat: add paired cylinder fields to Cylinder type and DTO"
+```
+
+---
+
+## Task 3: Eager-load the partner in cylinder GET routes
+
+**Files:**
+- Modify: `src/app/api/cylinders/route.tsx:12-14`
+- Modify: `src/app/api/clients/[clientId]/cylinders/route.tsx:19-23`
+
+The partner is loaded with a curated **non-date** attribute list. This keeps the nested object JSON-serializable (no dayjs getters fire) so it is safe to store in Redux.
+
+- [ ] **Step 1: Add the include to `GET /api/cylinders`**
+
+In `src/app/api/cylinders/route.tsx`, replace the `findAll` call (lines 12-14):
+
+```ts
+	const cylinders = await Cylinder.findAll({
+		include: [
+			{ model: Client, attributes: ['id', 'name'] },
+			{
+				model: Cylinder,
+				as: 'pairedCylinder',
+				attributes: [
+					'id',
+					'serialNumber',
+					'nickname',
+					'servicePressure',
+					'oxygenClean',
+					'ownerId',
+				],
+			},
+		],
+	})
+```
+
+- [ ] **Step 2: Add the include to `GET /api/clients/[clientId]/cylinders`**
+
+In `src/app/api/clients/[clientId]/cylinders/route.tsx`, replace the `findAll` call (lines 19-23):
+
+```ts
+	const cylinders = await Cylinder.findAll({
+		where: {
+			ownerId: clientId,
+		},
+		include: [
+			{
+				model: Cylinder,
+				as: 'pairedCylinder',
+				attributes: [
+					'id',
+					'serialNumber',
+					'nickname',
+					'servicePressure',
+					'oxygenClean',
+					'ownerId',
+				],
+			},
+		],
+	})
+```
+
+- [ ] **Step 3: Verify and manually check**
+
+Run: `npm run lint`
+Expected: passes.
+
+Then with the dev server running (`npm run dev`) and signed in, in the browser console or a terminal hit the cylinders endpoint and confirm the shape includes `pairedCylinder` (null until pairing exists):
+
+Run: `curl -s http://localhost:3000/api/cylinders -H "Cookie: <your session cookie>" | jq '.[0] | {id, serialNumber, pairedCylinder}'`
+Expected: an object with a `pairedCylinder` key (value `null` for unpaired cylinders). If auth makes curl impractical, instead confirm the dev server logs no Sequelize errors when the cylinders table loads on any page.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/cylinders/route.tsx "src/app/api/clients/[clientId]/cylinders/route.tsx"
+git commit -m "feat: eager-load paired cylinder in cylinder GET routes"
+```
+
+---
+
+## Task 4: Bidirectional pairing in the cylinder PUT route
+
+**Files:**
+- Modify: `src/app/api/cylinders/[cylinderId]/route.tsx`
+
+Note: the existing PUT route does not write audit logs (only DELETE does), so this task does not add one — staying consistent with current behavior.
+
+- [ ] **Step 1: Add the sequelize import**
+
+In `src/app/api/cylinders/[cylinderId]/route.tsx`, add the import after the existing model import (line 5):
+
+```ts
+import { Cylinder } from '@/lib/models/cylinder'
+import { sequelize } from '@/lib/models/config'
+```
+
+- [ ] **Step 2: Read `pairedCylinderId` from the body**
+
+In the PUT handler, add `pairedCylinderId` to the destructured body (the block at lines 26-36):
+
+```ts
+	const {
+		serialNumber,
+		birth,
+		lastHydro,
+		lastVis,
+		oxygenClean,
+		servicePressure,
+		nickname,
+		manufacturer,
+		size,
+		pairedCylinderId,
+	} = await request.json()
+```
+
+- [ ] **Step 3: Validate the partner before mutating**
+
+Immediately after the destructuring (before the `cylinder.serialNumber = ...` assignments), add validation. `pairedCylinderId === undefined` means "no change"; `null` means "clear"; a number means "pair to that cylinder":
+
+```ts
+	if (pairedCylinderId !== undefined && pairedCylinderId !== null) {
+		if (Number(pairedCylinderId) === cylinder.id) {
+			return Response.json(
+				{ error: 'invalid', message: 'A cylinder cannot be paired with itself' },
+				{ status: 400 },
+			)
+		}
+		const partner = await Cylinder.findByPk(pairedCylinderId)
+		if (!partner) {
+			return Response.json(
+				{ error: 'not_found', message: 'Paired cylinder not found' },
+				{ status: 400 },
+			)
+		}
+		if (partner.ownerId !== cylinder.ownerId) {
+			return Response.json(
+				{
+					error: 'invalid',
+					message: 'Paired cylinders must have the same owner',
+				},
+				{ status: 400 },
+			)
+		}
+	}
+```
+
+- [ ] **Step 4: Replace the save block with a transaction that maintains both pointers**
+
+Replace the scalar assignments and the `try { const result = await cylinder.save() ... }` block (lines 38-58) with:
+
+```ts
+	cylinder.serialNumber = serialNumber
+	cylinder.birth = dayjs(birth, 'YYYY-MM-DD')
+	cylinder.lastHydro = dayjs(lastHydro, 'YYYY-MM-DD')
+	cylinder.lastVis = dayjs(lastVis, 'YYYY-MM-DD')
+	cylinder.oxygenClean = oxygenClean
+	cylinder.servicePressure = servicePressure
+	cylinder.nickname = nickname || null
+	cylinder.manufacturer = manufacturer || null
+	cylinder.size = size ? Number(size) : null
+	cylinder.verified = true
+
+	const transaction = await sequelize.transaction()
+	try {
+		if (pairedCylinderId !== undefined) {
+			const previousPartnerId = cylinder.pairedCylinderId
+
+			if (pairedCylinderId === null) {
+				// Clearing: detach this cylinder and its old partner.
+				if (previousPartnerId) {
+					await Cylinder.update(
+						{ pairedCylinderId: null },
+						{ where: { id: previousPartnerId }, transaction },
+					)
+				}
+				cylinder.pairedCylinderId = null
+			} else {
+				// Pairing to a new partner.
+				// Detach this cylinder's old partner, if different.
+				if (previousPartnerId && previousPartnerId !== pairedCylinderId) {
+					await Cylinder.update(
+						{ pairedCylinderId: null },
+						{ where: { id: previousPartnerId }, transaction },
+					)
+				}
+				// Detach the new partner's existing partner, if any.
+				const partner = await Cylinder.findByPk(pairedCylinderId, {
+					transaction,
+				})
+				if (partner!.pairedCylinderId && partner!.pairedCylinderId !== cylinder.id) {
+					await Cylinder.update(
+						{ pairedCylinderId: null },
+						{ where: { id: partner!.pairedCylinderId }, transaction },
+					)
+				}
+				partner!.pairedCylinderId = cylinder.id
+				await partner!.save({ transaction })
+				cylinder.pairedCylinderId = pairedCylinderId
+			}
+		}
+
+		const result = await cylinder.save({ transaction })
+		await transaction.commit()
+		return Response.json(result)
+	} catch (err: any) {
+		await transaction.rollback()
+		console.error('error:', err)
+		return Response.json(
+			{ error: err.name, message: err.errors?.[0]?.message ?? err.message },
+			{ status: 400 },
+		)
+	}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 6: Manual check (deferred to Task 5)**
+
+The pairing UI does not exist yet, so end-to-end pairing is verified in Task 5. For now confirm the build:
+
+Run: `npm run build`
+Expected: build succeeds with no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "src/app/api/cylinders/[cylinderId]/route.tsx"
+git commit -m "feat: maintain bidirectional cylinder pairing in PUT route"
+```
+
+---
+
+## Task 5: Pairing control in the cylinder edit modal
+
+**Files:**
+- Modify: `src/components/Modals/CylinderModal.tsx`
+
+- [ ] **Step 1: Add state for the selected partner**
+
+In `src/components/Modals/CylinderModal.tsx`, after the `customManufacturer` state (line 76), add state seeded from the cylinder's existing partner. Cast the minimal partner shape to `Cylinder` for the picker's `value` prop:
+
+```ts
+	const [pairedCylinder, setPairedCylinder] = useState<Cylinder | null>(
+		(cylinder?.pairedCylinder as Cylinder) ?? null,
+	)
+```
+
+- [ ] **Step 2: Send `pairedCylinderId` with the form**
+
+In `handleSubmit`, after the size parsing block (after line 108, before `if (ownerId) {`), add:
+
+```ts
+		// Pairing is edit-only; for new cylinders this is null and ignored by the API.
+		formData.pairedCylinderId = pairedCylinder ? pairedCylinder.id : null
+```
+
+- [ ] **Step 3: Render the pairing picker (edit mode only)**
+
+In the form JSX, add this block after the oxygenClean `RadioGroup` (after line 268, before the buttons `<div className='flex w-full justify-end gap-2'>`). It renders only when editing an existing cylinder, lists the same owner's other cylinders, and offers a clear button:
+
+```tsx
+									{cylinder && (
+										<div className='space-y-2'>
+											<p className='text-text text-sm/6 font-medium'>
+												Paired cylinder (doubles)
+											</p>
+											<div className='flex items-end gap-2'>
+												<CylinderPicker
+													disableAdd={true}
+													value={pairedCylinder}
+													filter={(c) =>
+														c.id !== cylinder.id &&
+														c.ownerId === cylinder.ownerId
+													}
+													onChange={(c) => setPairedCylinder(c ?? null)}
+												/>
+												{pairedCylinder && (
+													<Button
+														variant='ghost'
+														onClick={() => setPairedCylinder(null)}
+													>
+														Clear
+													</Button>
+												)}
+											</div>
+										</div>
+									)}
+```
+
+- [ ] **Step 4: Add the CylinderPicker import**
+
+At the top of the file, after the `ListBox` import (line 25):
+
+```ts
+import ListBox from '../UI/FormElements/ListBox'
+import CylinderPicker from '../UI/FormElements/CylinderPicker'
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 6: Manual end-to-end check of pairing**
+
+Start the app (`docker compose up` for the DB, `npm run dev`). Sign in as an admin/filler. Create or pick a client with at least two cylinders. Open one cylinder's edit modal:
+- Confirm the "Paired cylinder (doubles)" picker appears and lists only that owner's other cylinders.
+- Select the second cylinder and save.
+- Reopen the **first** cylinder: the partner is shown. Reopen the **second** cylinder: it shows the first as its partner (bidirectional).
+- Edit the first cylinder, click "Clear", save. Reopen both: neither shows a partner.
+
+Expected: all of the above hold. If the partner does not display on reopen, confirm Task 3's GET include is returning `pairedCylinder`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Modals/CylinderModal.tsx
+git commit -m "feat: add paired cylinder picker to cylinder edit modal"
+```
+
+---
+
+## Task 6: Carry the partner in the in-progress fill entry
+
+**Files:**
+- Modify: `src/types/fills.ts:19-27`
+
+- [ ] **Step 1: Add `pairedCylinder` to the in-progress Fill type**
+
+In `src/types/fills.ts`, add the optional field to the `Fill` type:
+
+```ts
+export type Fill = {
+	id: number
+	type: FillType
+	start: number
+	end: number
+	o2: number
+	he: number
+	cylinder?: Cylinder
+	pairedCylinder?: Cylinder
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/fills.ts
+git commit -m "feat: add pairedCylinder to in-progress fill entry type"
+```
+
+---
+
+## Task 7: Combined paired row in the fills table and cards
+
+**Files:**
+- Modify: `src/components/Fills/FillsRow.tsx`
+- Modify: `src/components/Fills/FillCard.tsx`
+
+Both components share the same logic: include partners in the used-cylinder filter, set the partner when a paired cylinder is selected, and show the partner + an "unlink for this fill" control.
+
+- [ ] **Step 1: Update `FillsRow` — used filter, partner select, partner display**
+
+In `src/components/Fills/FillsRow.tsx`, replace the `usedCylinders` computation (lines 18-20) so partners count as used:
+
+```ts
+	const usedCylinders = useAppSelector((state) => state.fills)
+		.fills.flatMap((f) => [f.cylinder?.id, f.pairedCylinder?.id])
+		.filter((id) => id !== undefined)
+```
+
+Replace the `CylinderPicker`'s `onChange` (lines 30-41) so selecting a paired cylinder records its partner:
+
+```tsx
+					onChange={(val) =>
+						dispatch(
+							updateFill({
+								id: fill.id,
+								data: {
+									...fill,
+									cylinder: val || undefined,
+									pairedCylinder: val?.pairedCylinder
+										? (val.pairedCylinder as Cylinder)
+										: undefined,
+									end: fill.end === 0 && val ? val.servicePressure : fill.end,
+								},
+							}),
+						)
+					}
+```
+
+Add the `Cylinder` type import after the `Fill` import (line 7):
+
+```ts
+import { Fill } from '@/types/fills'
+import { Cylinder } from '@/types/cylinder'
+import { Client } from '@/types/client'
+```
+
+Inside the cylinder `<td>` (the one wrapping `CylinderPicker`, lines 24-43), add the partner indicator + unlink control directly after the closing `</CylinderPicker>` (i.e. after `/>` on line 42, still inside the `<td>`):
+
+```tsx
+					{fill.pairedCylinder && (
+						<div className='text-light-text mt-1 flex items-center gap-2 text-xs'>
+							<span>
+								+{' '}
+								{fill.pairedCylinder.nickname
+									? `${fill.pairedCylinder.nickname} (${fill.pairedCylinder.serialNumber})`
+									: fill.pairedCylinder.serialNumber}
+							</span>
+							<button
+								type='button'
+								className='underline'
+								onClick={() =>
+									dispatch(
+										updateFill({
+											id: fill.id,
+											data: { ...fill, pairedCylinder: undefined },
+										}),
+									)
+								}
+							>
+								unlink
+							</button>
+						</div>
+					)}
+```
+
+- [ ] **Step 2: Verify `FillsRow` compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 3: Update `FillCard` with the same three changes**
+
+In `src/components/Fills/FillCard.tsx`, replace the `usedCylinders` computation (lines 24-26):
+
+```ts
+	const usedCylinders = useAppSelector((state) => state.fills)
+		.fills.flatMap((f) => [f.cylinder?.id, f.pairedCylinder?.id])
+		.filter((id) => id !== undefined)
+```
+
+Replace the `CylinderPicker`'s `onChange` (lines 44-55):
+
+```tsx
+				onChange={(val) =>
+					dispatch(
+						updateFill({
+							id: fill.id,
+							data: {
+								...fill,
+								cylinder: val || undefined,
+								pairedCylinder: val?.pairedCylinder
+									? (val.pairedCylinder as Cylinder)
+									: undefined,
+								end: fill.end === 0 && val ? val.servicePressure : fill.end,
+							},
+						}),
+					)
+				}
+```
+
+Add the partner indicator + unlink control immediately after the `</CylinderPicker>` (`/>` on line 56), before `<FillType ... />`:
+
+```tsx
+			{fill.pairedCylinder && (
+				<div className='text-light-text flex items-center gap-2 text-sm'>
+					<span>
+						+{' '}
+						{fill.pairedCylinder.nickname
+							? `${fill.pairedCylinder.nickname} (${fill.pairedCylinder.serialNumber})`
+							: fill.pairedCylinder.serialNumber}
+					</span>
+					<button
+						type='button'
+						className='underline'
+						onClick={() =>
+							dispatch(
+								updateFill({
+									id: fill.id,
+									data: { ...fill, pairedCylinder: undefined },
+								}),
+							)
+						}
+					>
+						unlink
+					</button>
+				</div>
+			)}
+```
+
+Add the `Cylinder` type import after the `Fill` import (line 4):
+
+```ts
+import { Fill } from '@/types/fills'
+import { Cylinder } from '@/types/cylinder'
+```
+
+- [ ] **Step 4: Verify `FillCard` compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Fills/FillsRow.tsx src/components/Fills/FillCard.tsx
+git commit -m "feat: show combined paired cylinder row with unlink in fills UI"
+```
+
+---
+
+## Task 8: Validate gas/cert against both cylinders of a pair
+
+**Files:**
+- Modify: `src/components/Fills/FillType.tsx`
+- Modify: `src/components/Fills/FillsRow.tsx`
+- Modify: `src/components/Fills/FillCard.tsx`
+
+A paired fill writes the same gas to both cylinders, so nitrox/trimix must be allowed only when **both** cylinders are oxygen-clean (the client cert check is unchanged).
+
+- [ ] **Step 1: Accept a `pairedCylinder` prop in `FillType` and require both clean**
+
+In `src/components/Fills/FillType.tsx`, add `pairedCylinder` to the props type (after `cylinder?: Cylinder` on line 28):
+
+```ts
+type FillTypeProps = {
+	index: number
+	item: Fill
+	client?: Client
+	cylinder?: Cylinder
+	pairedCylinder?: Cylinder
+}
+```
+
+Destructure it in the component signature (line 38):
+
+```ts
+const FillType = ({ index, item, client, cylinder, pairedCylinder }: FillTypeProps) => {
+```
+
+Replace the `nitroxUse` / `trimixUse` computation (lines 41-45) so the partner must also be oxygen-clean when present:
+
+```ts
+	const bothOxygenClean =
+		cylinder?.oxygenClean == true &&
+		(!pairedCylinder || pairedCylinder.oxygenClean == true)
+
+	const nitroxUse =
+		bothOxygenClean &&
+		!!(client && (client.nitroxCert || client.advancedNitroxCert))
+	const trimixUse = bothOxygenClean && !!(client && client.trimixCert)
+```
+
+- [ ] **Step 2: Pass the partner from `FillsRow`**
+
+In `src/components/Fills/FillsRow.tsx`, add the prop to the `FillType` element (the block at lines 45-50):
+
+```tsx
+				<FillType
+					index={fill.id}
+					item={fill}
+					client={client || undefined}
+					cylinder={fill.cylinder}
+					pairedCylinder={fill.pairedCylinder}
+				/>
+```
+
+- [ ] **Step 3: Pass the partner from `FillCard`**
+
+In `src/components/Fills/FillCard.tsx`, add the prop to the `FillType` element (the block at lines 57-62):
+
+```tsx
+			<FillType
+				index={fill.id}
+				item={fill}
+				client={client || undefined}
+				cylinder={fill.cylinder}
+				pairedCylinder={fill.pairedCylinder}
+			/>
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 5: Manual check**
+
+With a paired set where the two cylinders differ in oxygen-clean status (edit one cylinder's "oxygen clean" to No, save), select that set on the fills page and open the gas-type dropdown. Confirm Nitrox/Trimix show the cert warning (uncertified) because not both cylinders are oxygen-clean. Set both to oxygen-clean and confirm Nitrox/Trimix become available (given client cert).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Fills/FillType.tsx src/components/Fills/FillsRow.tsx src/components/Fills/FillCard.tsx
+git commit -m "feat: validate fill gas type against both cylinders of a pair"
+```
+
+---
+
+## Task 9: Expand paired entries into two FillDto on submit
+
+**Files:**
+- Modify: `src/app/fills/page.tsx:27-36`
+
+- [ ] **Step 1: Replace the fill mapping with an expansion**
+
+In `src/app/fills/page.tsx`, replace the `fills.map(...)` that builds `fillData` (lines 27-36) with a `flatMap` that emits a second record for a paired cylinder:
+
+```ts
+		const fillData: FillDto[] = fills.flatMap((fill) => {
+			const base = {
+				date: dayjs(fillDate as string),
+				startPressure: fill.start,
+				endPressure: fill.end,
+				oxygen: fill.o2,
+				helium: fill.he,
+			}
+
+			const records: FillDto[] = [{ ...base, cylinderId: fill.cylinder?.id }]
+
+			if (fill.pairedCylinder) {
+				records.push({ ...base, cylinderId: fill.pairedCylinder.id })
+			}
+
+			return records
+		})
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 3: Manual end-to-end check of a paired fill**
+
+With the app running and a paired set already configured (from Task 5):
+- Go to "Record a Tank Fill", pick the client, add a fill, and select the **first** cylinder of the pair via the cylinder picker.
+- Confirm the row shows the partner ("+ <partner>") and a single set of pressure/gas inputs.
+- Confirm neither cylinder of the pair can be selected again in a second fill row (both filtered out).
+- Enter start/end pressure and gas mix once, submit.
+- Verify in the fill history (or `GET /api/fills`) that **two** Fill records were created — one per cylinder — with identical date, pressures, and gas mix.
+- Repeat, but click "unlink" before submitting: confirm only **one** Fill record is created and the partner becomes selectable again.
+
+Expected: all of the above hold.
+
+- [ ] **Step 4: Build check**
+
+Run: `npm run build`
+Expected: build succeeds with no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/fills/page.tsx
+git commit -m "feat: expand paired cylinder fills into two records on submit"
+```
+
+---
+
+## Task 10 (optional): Paired indicator in the cylinder list
+
+**Files:**
+- Modify: `src/components/Cylinders/CylinderListRow.tsx`
+
+Low priority — include only if it fits the row cleanly.
+
+- [ ] **Step 1: Add a small partner line under the cylinder name**
+
+In `src/components/Cylinders/CylinderListRow.tsx`, inside the cylinder-name `<td>` (lines 46-57), add a partner line after the nickname/serial block. Replace the cell body so the partner shows when present:
+
+```tsx
+			<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>
+				{cylinder.nickname ? (
+					<div className='flex flex-col items-center'>
+						<span>{cylinder.nickname}</span>
+						<span className='text-light-text text-xs'>
+							{cylinder.serialNumber}
+						</span>
+					</div>
+				) : (
+					cylinder.serialNumber
+				)}
+				{cylinder.pairedCylinder && (
+					<div className='text-light-text mt-1 text-xs'>
+						🔗 {cylinder.pairedCylinder.nickname ?? cylinder.pairedCylinder.serialNumber}
+					</div>
+				)}
+			</td>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run lint`
+Expected: passes with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Cylinders/CylinderListRow.tsx
+git commit -m "feat: show paired cylinder indicator in cylinder list"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `npm run lint` — passes.
+- [ ] Run `npm run build` — succeeds.
+- [ ] Re-run the manual checks in Task 5 (bidirectional pairing), Task 8 (gas type requires both cylinders oxygen-clean), and Task 9 (paired fill creates two records; unlink creates one).
+- [ ] Confirm deleting a paired cylinder (admin) leaves the partner's `pairedCylinderId` null (the `ON DELETE SET NULL` FK handles this) — delete one cylinder of a pair and reopen the survivor's edit modal to confirm it shows no partner.

--- a/docs/superpowers/specs/2026-06-07-paired-cylinders-design.md
+++ b/docs/superpowers/specs/2026-06-07-paired-cylinders-design.md
@@ -1,0 +1,158 @@
+# Paired Cylinders (Doubles) — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (pending spec review)
+
+## Problem
+
+A set of doubles (twinset) is two cylinders manifolded together that share the
+same gas mix and pressure. Today each Fill record maps 1:1 to a single cylinder
+and there is no concept of grouping. Recording a fill for a double means adding
+two separate rows in the fills page and re-entering the same pressures and gas
+mix twice. This is tedious and error-prone.
+
+## Goal
+
+Let a user define two cylinders as a persistent pair, then fill them as a single
+unit — entering pressure and gas mix once — while still keeping per-cylinder fill
+records for history and inspections.
+
+## Decisions
+
+- **Persistent set**, modeled as a **pairing field on the cylinder** (a nullable
+  self-referential `pairedCylinderId`), not a separate set model. Supports pairs
+  only (not triples).
+- Pairing is restricted to cylinders owned by the **same client**.
+- A cylinder is in **at most one** pair. Re-pairing reassigns and clears the old
+  partner.
+- A paired fill still produces **two Fill records** (one per cylinder). Fill
+  history, edits, and visual inspections are unchanged — the DB Fill schema and
+  the POST `/api/fills` route need no change.
+- Fill-time behavior: selecting one cylinder of a pair shows a **single combined
+  row with shared inputs**; both cylinders are filled with identical values on
+  submit, with an option to unlink for the occasional single-tank fill.
+
+## 1. Data model
+
+Add a nullable column `pairedCylinderId` (INTEGER, FK → `cylinders.id`,
+`ON DELETE SET NULL`) to the Cylinder model.
+
+- **Migration** (`migrations/`, CJS, `YYYYMMDDNNNNNN-add-paired-cylinder-id.cjs`):
+  add the column and a self-referential foreign key constraint with
+  `onDelete: 'SET NULL'`.
+- **Model** (`src/lib/models/cylinder/index.tsx`): declare the `pairedCylinderId`
+  attribute and a self-association (`Cylinder.belongsTo(Cylinder, { as: 'pairedCylinder', foreignKey: 'pairedCylinderId' })`)
+  so the partner can be eager-loaded.
+- **Type** (`src/types/cylinder.ts`): add `pairedCylinderId?: number | null` and
+  an optional eager-loaded `pairedCylinder?` (minimal shape: id, serialNumber,
+  nickname, servicePressure, oxygenClean) to `Cylinder`. Add
+  `pairedCylinderId?: number | null` to the create/edit DTO.
+- Two cylinders in a double point at each other (A→B and B→A). Both pointers are
+  kept consistent by the API (see §4).
+
+## 2. Pairing management (CylinderModal)
+
+Pairing is **edit-only** — a cylinder must exist before it can be paired, so the
+create flow is unchanged.
+
+In `src/components/Modals/CylinderModal.tsx`, when editing an existing cylinder,
+add a "Paired cylinder" control:
+
+- A `CylinderPicker` in **controlled mode** (`value`/`onChange`), listing only
+  the **same owner's** other cylinders, excluding the cylinder being edited.
+- Selecting a cylinder links them; clearing the selection unlinks.
+- The selected `pairedCylinderId` is submitted with the rest of the form to the
+  PUT route.
+- Show nothing (or a disabled hint) in the create flow.
+
+## 3. Fill recording (fills page)
+
+When a cylinder selected via `CylinderPicker` (in `FillsRow` / `FillCard`) has a
+`pairedCylinder`, the row becomes a **combined paired row**:
+
+- The cylinder cell shows both cylinders, e.g. `Yellow Set — SN123 + SN124`
+  (fall back to serials when no nickname).
+- Pressure and gas-mix inputs appear **once** and apply to both cylinders.
+- Both cylinders are marked "used" so neither can be re-selected elsewhere in the
+  batch (the existing used-cylinder filter must account for partners).
+- A small **"unlink for this fill"** control drops the partner, reverting to a
+  normal single-cylinder row (for filling just one tank of a set).
+
+**State/Redux** (`src/redux/fills/fillsSlice.ts`):
+
+- The in-progress fill entry (`Fill` in `src/types/fills.ts`) gains an optional
+  `pairedCylinder?: Cylinder`.
+- A `updateCylinder` action that selects a cylinder with a partner also sets
+  `pairedCylinder`. Add an action (or reuse `updateFill`/`updateCylinder`) to
+  clear `pairedCylinder` for the unlink control.
+
+**Submit** (fills page submit handler):
+
+- When mapping fill entries to `FillDto[]`, any entry carrying a `pairedCylinder`
+  expands into **two `FillDto` records** with identical `date`, `startPressure`,
+  `endPressure`, `oxygen`, `helium` — one per cylinder id.
+- POST `/api/fills` is unchanged.
+
+**Auto end-pressure:** when a paired cylinder is selected and end pressure is 0,
+auto-fill from the **selected (primary)** cylinder's `servicePressure` (existing
+behavior, applied once).
+
+## 4. API changes
+
+`PUT /api/cylinders/[cylinderId]` (`src/app/api/cylinders/[cylinderId]/route.tsx`)
+accepts `pairedCylinderId` and maintains bidirectional consistency inside a
+**transaction**:
+
+1. Validate the target partner (if provided) exists and has the **same owner**;
+   reject otherwise (400).
+2. Let `old = current cylinder.pairedCylinderId`.
+3. If pairing to B:
+   - If B was paired to some D (≠ this cylinder), clear `D.pairedCylinderId`.
+   - If this cylinder was paired to some C (≠ B), clear `C.pairedCylinderId`.
+   - Set `this.pairedCylinderId = B` and `B.pairedCylinderId = this`.
+4. If clearing (null):
+   - Set `this.pairedCylinderId = null` and, if `old` existed, clear that
+     partner's pointer too.
+5. Audit-log the pairing change consistent with existing PUT audit behavior.
+
+`GET` cylinder routes eager-load `pairedCylinder` so the fills page and cylinder
+list have partner data available.
+
+## 5. Display (cylinder list)
+
+Optionally show a small "paired" indicator on `CylinderListRow.tsx` (e.g. a link
+chip referencing the partner serial). Low priority; include only if it fits
+cleanly within the existing row layout.
+
+## 6. Edge cases
+
+- **Mismatched `servicePressure`** between partners: auto-fill end pressure from
+  the selected (primary) cylinder. Rare for true doubles.
+- **Gas/cert validation** (oxygen clean; nitrox/trimix certs): validated against
+  **both** cylinders; if either fails, show the existing warning dialog.
+- **Deleting a cylinder**: `ON DELETE SET NULL` clears the partner's pointer
+  automatically at the DB level.
+- **Same-owner constraint**: enforced server-side; the picker also filters by
+  owner client-side.
+
+## Out of scope
+
+- Sets larger than two cylinders (manifolded banks of 3+).
+- Editing/splitting an already-recorded paired fill as a unit — edits remain
+  per-record via the existing EditFillModal.
+- A dedicated CylinderSet model or named sets.
+
+## Files touched
+
+- `migrations/YYYYMMDDNNNNNN-add-paired-cylinder-id.cjs` (new)
+- `src/lib/models/cylinder/index.tsx`
+- `src/types/cylinder.ts`
+- `src/types/fills.ts`
+- `src/components/Modals/CylinderModal.tsx`
+- `src/app/api/cylinders/[cylinderId]/route.tsx`
+- cylinder GET routes (`src/app/api/cylinders/route.tsx`,
+  `src/app/api/clients/[clientId]/cylinders/route.tsx`) — eager-load partner
+- `src/redux/fills/fillsSlice.ts`
+- `src/components/` fills row/card + `CylinderPicker` (combined paired row, unlink)
+- fills page submit handler (`src/app/fills/page.tsx`)
+- `src/components/Cylinders/CylinderListRow.tsx` (optional indicator)

--- a/migrations/20260607000001-add-cylinder-paired.cjs
+++ b/migrations/20260607000001-add-cylinder-paired.cjs
@@ -1,0 +1,19 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		await queryInterface.addColumn('Cylinders', 'pairedCylinderId', {
+			type: Sequelize.INTEGER.UNSIGNED,
+			allowNull: true,
+			defaultValue: null,
+			references: { model: 'Cylinders', key: 'id' },
+			onUpdate: 'CASCADE',
+			onDelete: 'SET NULL',
+		})
+	},
+
+	async down(queryInterface) {
+		await queryInterface.removeColumn('Cylinders', 'pairedCylinderId')
+	},
+}

--- a/src/app/api/clients/[clientId]/cylinders/route.tsx
+++ b/src/app/api/clients/[clientId]/cylinders/route.tsx
@@ -20,6 +20,20 @@ export async function GET(
 		where: {
 			ownerId: clientId,
 		},
+		include: [
+			{
+				model: Cylinder,
+				as: 'pairedCylinder',
+				attributes: [
+					'id',
+					'serialNumber',
+					'nickname',
+					'servicePressure',
+					'oxygenClean',
+					'ownerId',
+				],
+			},
+		],
 	})
 
 	return Response.json(cylinders)

--- a/src/app/api/cylinders/[cylinderId]/route.tsx
+++ b/src/app/api/cylinders/[cylinderId]/route.tsx
@@ -3,6 +3,7 @@ import { requireRole, isErrorResponse } from '@/lib/permissions-server'
 import { auditLog } from '@/lib/audit'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import { Cylinder } from '@/lib/models/cylinder'
+import { sequelize } from '@/lib/models/config'
 dayjs.extend(customParseFormat)
 
 export async function PUT(
@@ -33,7 +34,36 @@ export async function PUT(
 		nickname,
 		manufacturer,
 		size,
+		pairedCylinderId,
 	} = await request.json()
+
+	if (pairedCylinderId !== undefined && pairedCylinderId !== null) {
+		if (Number(pairedCylinderId) === cylinder.id) {
+			return Response.json(
+				{
+					error: 'invalid',
+					message: 'A cylinder cannot be paired with itself',
+				},
+				{ status: 400 },
+			)
+		}
+		const partner = await Cylinder.findByPk(pairedCylinderId)
+		if (!partner) {
+			return Response.json(
+				{ error: 'not_found', message: 'Paired cylinder not found' },
+				{ status: 400 },
+			)
+		}
+		if (partner.ownerId !== cylinder.ownerId) {
+			return Response.json(
+				{
+					error: 'invalid',
+					message: 'Paired cylinders must have the same owner',
+				},
+				{ status: 400 },
+			)
+		}
+	}
 
 	cylinder.serialNumber = serialNumber
 	cylinder.birth = dayjs(birth, 'YYYY-MM-DD')
@@ -46,13 +76,63 @@ export async function PUT(
 	cylinder.size = size ? Number(size) : null
 	cylinder.verified = true
 
+	const transaction = await sequelize.transaction()
 	try {
-		const result = await cylinder.save()
+		if (pairedCylinderId !== undefined) {
+			const previousPartnerId = cylinder.pairedCylinderId
+
+			if (pairedCylinderId === null) {
+				// Clearing: detach this cylinder and its old partner.
+				if (previousPartnerId) {
+					await Cylinder.update(
+						{ pairedCylinderId: null },
+						{ where: { id: previousPartnerId }, transaction },
+					)
+				}
+				cylinder.pairedCylinderId = null
+			} else {
+				// Pairing to a new partner.
+				// Detach this cylinder's old partner, if different.
+				if (previousPartnerId && previousPartnerId !== pairedCylinderId) {
+					await Cylinder.update(
+						{ pairedCylinderId: null },
+						{ where: { id: previousPartnerId }, transaction },
+					)
+				}
+				// Detach the new partner's existing partner, if any.
+				const partner = await Cylinder.findByPk(pairedCylinderId, {
+					transaction,
+				})
+				if (!partner) {
+					await transaction.rollback()
+					return Response.json(
+						{ error: 'not_found', message: 'Paired cylinder not found' },
+						{ status: 400 },
+					)
+				}
+				if (
+					partner.pairedCylinderId &&
+					partner.pairedCylinderId !== cylinder.id
+				) {
+					await Cylinder.update(
+						{ pairedCylinderId: null },
+						{ where: { id: partner.pairedCylinderId }, transaction },
+					)
+				}
+				partner.pairedCylinderId = cylinder.id
+				await partner.save({ transaction })
+				cylinder.pairedCylinderId = pairedCylinderId
+			}
+		}
+
+		const result = await cylinder.save({ transaction })
+		await transaction.commit()
 		return Response.json(result)
 	} catch (err: any) {
+		await transaction.rollback()
 		console.error('error:', err)
 		return Response.json(
-			{ error: err.name, message: err.errors[0].message },
+			{ error: err.name, message: err.errors?.[0]?.message ?? err.message },
 			{ status: 400 },
 		)
 	}

--- a/src/app/api/cylinders/route.tsx
+++ b/src/app/api/cylinders/route.tsx
@@ -10,7 +10,21 @@ export async function GET(request: Request) {
 	if (isErrorResponse(result)) return result
 
 	const cylinders = await Cylinder.findAll({
-		include: [{ model: Client, attributes: ['id', 'name'] }],
+		include: [
+			{ model: Client, attributes: ['id', 'name'] },
+			{
+				model: Cylinder,
+				as: 'pairedCylinder',
+				attributes: [
+					'id',
+					'serialNumber',
+					'nickname',
+					'servicePressure',
+					'oxygenClean',
+					'ownerId',
+				],
+			},
+		],
 	})
 
 	return Response.json(cylinders)

--- a/src/app/fills/page.tsx
+++ b/src/app/fills/page.tsx
@@ -24,15 +24,22 @@ export default function Fills() {
 
 		const { fillDate } = formData
 
-		const fillData: FillDto[] = fills.map((fill) => {
-			return {
+		const fillData: FillDto[] = fills.flatMap((fill) => {
+			const base = {
 				date: dayjs(fillDate as string),
-				cylinderId: fill.cylinder?.id,
 				startPressure: fill.start,
 				endPressure: fill.end,
 				oxygen: fill.o2,
 				helium: fill.he,
 			}
+
+			const records: FillDto[] = [{ ...base, cylinderId: fill.cylinder?.id }]
+
+			if (fill.pairedCylinder) {
+				records.push({ ...base, cylinderId: fill.pairedCylinder.id })
+			}
+
+			return records
 		})
 
 		const data = await addNewFill(fillData)

--- a/src/components/Cylinders/CylinderListRow.tsx
+++ b/src/components/Cylinders/CylinderListRow.tsx
@@ -5,6 +5,7 @@ import {
 	XCircleIcon,
 	InformationCircleIcon,
 	Cog6ToothIcon,
+	LinkIcon,
 } from '@heroicons/react/24/outline'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/solid'
 import dayjs from 'dayjs'
@@ -55,10 +56,12 @@ const CylinderListRow = ({
 					cylinder.serialNumber
 				)}
 				{cylinder.pairedCylinder && (
-					<div className='text-light-text mt-1 text-xs'>
-						🔗{' '}
-						{cylinder.pairedCylinder.nickname ??
-							cylinder.pairedCylinder.serialNumber}
+					<div className='text-light-text mt-1 flex items-center justify-center gap-1 text-xs'>
+						<LinkIcon className='h-3 w-3' />
+						<span>
+							{cylinder.pairedCylinder.nickname ??
+								cylinder.pairedCylinder.serialNumber}
+						</span>
 					</div>
 				)}
 			</td>

--- a/src/components/Cylinders/CylinderListRow.tsx
+++ b/src/components/Cylinders/CylinderListRow.tsx
@@ -54,6 +54,13 @@ const CylinderListRow = ({
 				) : (
 					cylinder.serialNumber
 				)}
+				{cylinder.pairedCylinder && (
+					<div className='text-light-text mt-1 text-xs'>
+						🔗{' '}
+						{cylinder.pairedCylinder.nickname ??
+							cylinder.pairedCylinder.serialNumber}
+					</div>
+				)}
 			</td>
 			{showOwner && (
 				<td className='text-text py-4 pr-3 pl-4 text-center text-sm font-medium whitespace-nowrap sm:pl-6'>

--- a/src/components/Fills/FillCard.tsx
+++ b/src/components/Fills/FillCard.tsx
@@ -2,6 +2,7 @@ import { removeFill, updateFill } from '@/redux/fills/fillsSlice'
 import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 import { Client } from '@/types/client'
 import { Fill } from '@/types/fills'
+import { Cylinder } from '@/types/cylinder'
 import { XCircleIcon } from '@heroicons/react/24/outline'
 import CylinderPicker from '../UI/FormElements/CylinderPicker'
 import FillType from './FillType'
@@ -22,7 +23,7 @@ const FillCard = ({
 }: FillsRowProps) => {
 	const dispatch = useAppDispatch()
 	const usedCylinders = useAppSelector((state) => state.fills)
-		.fills.map((f) => f.cylinder?.id)
+		.fills.flatMap((f) => [f.cylinder?.id, f.pairedCylinder?.id])
 		.filter((id) => id !== undefined)
 	return (
 		<div className='bg-surface flex min-w-full flex-col gap-2 rounded p-4'>
@@ -48,12 +49,39 @@ const FillCard = ({
 							data: {
 								...fill,
 								cylinder: val || undefined,
+								pairedCylinder: val?.pairedCylinder
+									? (val.pairedCylinder as Cylinder)
+									: undefined,
 								end: fill.end === 0 && val ? val.servicePressure : fill.end,
 							},
 						}),
 					)
 				}
 			/>
+			{fill.pairedCylinder && (
+				<div className='text-light-text flex items-center gap-2 text-sm'>
+					<span>
+						+{' '}
+						{fill.pairedCylinder.nickname
+							? `${fill.pairedCylinder.nickname} (${fill.pairedCylinder.serialNumber})`
+							: fill.pairedCylinder.serialNumber}
+					</span>
+					<button
+						type='button'
+						className='underline'
+						onClick={() =>
+							dispatch(
+								updateFill({
+									id: fill.id,
+									data: { ...fill, pairedCylinder: undefined },
+								}),
+							)
+						}
+					>
+						unlink
+					</button>
+				</div>
+			)}
 			<FillType
 				index={fill.id}
 				item={fill}

--- a/src/components/Fills/FillCard.tsx
+++ b/src/components/Fills/FillCard.tsx
@@ -87,6 +87,7 @@ const FillCard = ({
 				item={fill}
 				client={client || undefined}
 				cylinder={fill.cylinder}
+				pairedCylinder={fill.pairedCylinder}
 			/>
 			<div className='flex flex-row gap-2'>
 				<NumberInput

--- a/src/components/Fills/FillType.tsx
+++ b/src/components/Fills/FillType.tsx
@@ -26,6 +26,7 @@ type FillTypeProps = {
 	item: Fill
 	client?: Client
 	cylinder?: Cylinder
+	pairedCylinder?: Cylinder
 }
 
 type FillOption = {
@@ -35,14 +36,23 @@ type FillOption = {
 	warning?: string
 }
 
-const FillType = ({ index, item, client, cylinder }: FillTypeProps) => {
+const FillType = ({
+	index,
+	item,
+	client,
+	cylinder,
+	pairedCylinder,
+}: FillTypeProps) => {
 	const dispatch = useAppDispatch()
 
-	const nitroxUse =
+	const bothOxygenClean =
 		cylinder?.oxygenClean == true &&
+		(!pairedCylinder || pairedCylinder.oxygenClean == true)
+
+	const nitroxUse =
+		bothOxygenClean &&
 		!!(client && (client.nitroxCert || client.advancedNitroxCert))
-	const trimixUse =
-		cylinder?.oxygenClean == true && !!(client && client.trimixCert)
+	const trimixUse = bothOxygenClean && !!(client && client.trimixCert)
 
 	const options: FillOption[] = [
 		{ value: 'air', label: 'Air', certified: true },

--- a/src/components/Fills/FillsRow.tsx
+++ b/src/components/Fills/FillsRow.tsx
@@ -75,6 +75,7 @@ const FillsRow = ({ disableDelete = false, fill, client }: FillsRowProps) => {
 					item={fill}
 					client={client || undefined}
 					cylinder={fill.cylinder}
+					pairedCylinder={fill.pairedCylinder}
 				/>
 			</td>
 			<td className='text-light-text px-3 py-4 text-sm whitespace-nowrap'>

--- a/src/components/Fills/FillsRow.tsx
+++ b/src/components/Fills/FillsRow.tsx
@@ -5,6 +5,7 @@ import { removeFill, updateFill } from '@/redux/fills/fillsSlice'
 import NumberInput from '../UI/FormElements/NumberInput'
 import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 import { Fill } from '@/types/fills'
+import { Cylinder } from '@/types/cylinder'
 import { Client } from '@/types/client'
 
 type FillsRowProps = {
@@ -16,7 +17,7 @@ type FillsRowProps = {
 const FillsRow = ({ disableDelete = false, fill, client }: FillsRowProps) => {
 	const dispatch = useAppDispatch()
 	const usedCylinders = useAppSelector((state) => state.fills)
-		.fills.map((f) => f.cylinder?.id)
+		.fills.flatMap((f) => [f.cylinder?.id, f.pairedCylinder?.id])
 		.filter((id) => id !== undefined)
 
 	return (
@@ -34,12 +35,39 @@ const FillsRow = ({ disableDelete = false, fill, client }: FillsRowProps) => {
 								data: {
 									...fill,
 									cylinder: val || undefined,
+									pairedCylinder: val?.pairedCylinder
+										? (val.pairedCylinder as Cylinder)
+										: undefined,
 									end: fill.end === 0 && val ? val.servicePressure : fill.end,
 								},
 							}),
 						)
 					}
 				/>
+				{fill.pairedCylinder && (
+					<div className='text-light-text mt-1 flex items-center gap-2 text-xs'>
+						<span>
+							+{' '}
+							{fill.pairedCylinder.nickname
+								? `${fill.pairedCylinder.nickname} (${fill.pairedCylinder.serialNumber})`
+								: fill.pairedCylinder.serialNumber}
+						</span>
+						<button
+							type='button'
+							className='underline'
+							onClick={() =>
+								dispatch(
+									updateFill({
+										id: fill.id,
+										data: { ...fill, pairedCylinder: undefined },
+									}),
+								)
+							}
+						>
+							unlink
+						</button>
+					</div>
+				)}
 			</td>
 			<td className='text-text py-4 text-sm font-medium whitespace-nowrap'>
 				<FillType

--- a/src/components/Modals/CylinderModal.tsx
+++ b/src/components/Modals/CylinderModal.tsx
@@ -23,6 +23,7 @@ import ClientPicker from '../UI/FormElements/ClientPicker'
 import DatePicker from '../UI/FormElements/DatePicker'
 import Button from '../UI/Button'
 import ListBox from '../UI/FormElements/ListBox'
+import CylinderPicker from '../UI/FormElements/CylinderPicker'
 import { newCylinder } from '@/app/_api'
 import { Cylinder, NewCylinderDTO } from '@/types/cylinder'
 import { toast } from 'react-toastify'
@@ -74,6 +75,9 @@ const CylinderModal = ({
 	const [customManufacturer, setCustomManufacturer] = useState(
 		isKnown ? '' : initialManufacturer,
 	)
+	const [pairedCylinder, setPairedCylinder] = useState<Cylinder | null>(
+		(cylinder?.pairedCylinder as Cylinder) ?? null,
+	)
 
 	const { selectedClient, allClients: clients } = useAppSelector(
 		(state) => state.clients,
@@ -106,6 +110,9 @@ const CylinderModal = ({
 			const parsed = Number(formData.size)
 			formData.size = isNaN(parsed) || parsed <= 0 ? undefined : parsed
 		}
+
+		// Pairing is edit-only; for new cylinders this is null and ignored by the API.
+		formData.pairedCylinderId = pairedCylinder ? pairedCylinder.id : null
 
 		if (ownerId) {
 			const data = await onSubmit(
@@ -267,6 +274,32 @@ const CylinderModal = ({
 										}
 									/>
 
+									{cylinder && (
+										<div className='space-y-2'>
+											<p className='text-text text-sm/6 font-medium'>
+												Paired cylinder (doubles)
+											</p>
+											<div className='flex items-end gap-2'>
+												<CylinderPicker
+													disableAdd={true}
+													value={pairedCylinder}
+													filter={(c) =>
+														c.id !== cylinder.id &&
+														c.ownerId === cylinder.ownerId
+													}
+													onChange={(c) => setPairedCylinder(c ?? null)}
+												/>
+												{pairedCylinder && (
+													<Button
+														variant='ghost'
+														onClick={() => setPairedCylinder(null)}
+													>
+														Clear
+													</Button>
+												)}
+											</div>
+										</div>
+									)}
 									<div className='flex w-full justify-end gap-2'>
 										<Button onClick={handleClose} variant='ghost'>
 											{cancelText}

--- a/src/hooks/useLoadCylinders.ts
+++ b/src/hooks/useLoadCylinders.ts
@@ -28,6 +28,7 @@ const useLoadCylinder = () => {
 				lastVis: data.lastVis ? dayjs(data.lastVis).toISOString() : '',
 				createdAt: data.createdAt ? dayjs(data.createdAt).toISOString() : '',
 				updatedAt: data.updatedAt ? dayjs(data.updatedAt).toISOString() : '',
+				pairedCylinder: data.pairedCylinder ?? null,
 			}
 		})
 	}, [data])

--- a/src/lib/models/cylinder/index.tsx
+++ b/src/lib/models/cylinder/index.tsx
@@ -27,8 +27,8 @@ import { Fill } from '../fill'
 import { Visual } from '../visual'
 
 export class Cylinder extends Model<
-	InferAttributes<Cylinder, { omit: 'Client' }>,
-	InferCreationAttributes<Cylinder, { omit: 'Client' }>
+	InferAttributes<Cylinder, { omit: 'Client' | 'pairedCylinder' }>,
+	InferCreationAttributes<Cylinder, { omit: 'Client' | 'pairedCylinder' }>
 > {
 	// 'CreationOptional' is a special type that marks the field as optional
 	// when creating an instance of the model (such as using Model.create()).
@@ -55,6 +55,9 @@ export class Cylinder extends Model<
 	declare manufacturer: CreationOptional<string | null>
 	declare size: CreationOptional<number | null>
 
+	declare pairedCylinderId: CreationOptional<ForeignKey<Cylinder['id']> | null>
+	declare pairedCylinder?: NonAttribute<Cylinder>
+
 	// timestamps!
 	// createdAt can be undefined during creation
 	declare createdAt: CreationOptional<Date>
@@ -63,6 +66,12 @@ export class Cylinder extends Model<
 
 	declare getOwner: BelongsToGetAssociationMixin<Client>
 	declare setOwner: BelongsToSetAssociationMixin<Client, Client['id']>
+
+	declare getPairedCylinder: BelongsToGetAssociationMixin<Cylinder>
+	declare setPairedCylinder: BelongsToSetAssociationMixin<
+		Cylinder,
+		Cylinder['id']
+	>
 
 	declare getFills: HasManyGetAssociationsMixin<Fill> // Note the null assertions!
 	declare addFill: HasManyAddAssociationMixin<Fill, number>
@@ -94,6 +103,7 @@ export class Cylinder extends Model<
 		owner: Association<Cylinder, Client>
 		fills: Association<Fill, Cylinder>
 		visuals: Association<Visual, Cylinder>
+		pairedCylinder: Association<Cylinder, Cylinder>
 	}
 }
 
@@ -165,6 +175,11 @@ Cylinder.init(
 			allowNull: true,
 			defaultValue: null,
 		},
+		pairedCylinderId: {
+			type: DataTypes.INTEGER.UNSIGNED,
+			allowNull: true,
+			defaultValue: null,
+		},
 		createdAt: DataTypes.DATE,
 		updatedAt: DataTypes.DATE,
 	},
@@ -176,3 +191,8 @@ Cylinder.init(
 
 Cylinder.belongsTo(Client, { foreignKey: 'ownerId' })
 Client.hasMany(Cylinder, { foreignKey: 'ownerId' })
+
+Cylinder.belongsTo(Cylinder, {
+	as: 'pairedCylinder',
+	foreignKey: 'pairedCylinderId',
+})

--- a/src/types/cylinder.ts
+++ b/src/types/cylinder.ts
@@ -13,6 +13,15 @@ export type Cylinder = {
 	nickname?: string | null
 	manufacturer?: string | null
 	size?: number | null
+	pairedCylinderId?: number | null
+	pairedCylinder?: {
+		id: number
+		serialNumber: string
+		nickname?: string | null
+		servicePressure: number
+		oxygenClean: boolean
+		ownerId?: number
+	} | null
 	createdAt?: string
 	updatedAt?: string
 }
@@ -28,4 +37,5 @@ export type NewCylinderDTO = {
 	nickname?: string
 	manufacturer?: string
 	size?: number
+	pairedCylinderId?: number | null
 }

--- a/src/types/fills.ts
+++ b/src/types/fills.ts
@@ -24,6 +24,7 @@ export type Fill = {
 	o2: number
 	he: number
 	cylinder?: Cylinder
+	pairedCylinder?: Cylinder
 }
 
 export type FillDto = {


### PR DESCRIPTION
- **docs: add paired cylinders (doubles) design spec**
- **docs: add paired cylinders implementation plan**
- **feat: add pairedCylinderId column and self-association to Cylinder**
- **feat: add paired cylinder fields to Cylinder type and DTO**
- **feat: eager-load paired cylinder in cylinder GET routes**
- **feat: maintain bidirectional cylinder pairing in PUT route**
- **feat: add paired cylinder picker to cylinder edit modal**
- **feat: add pairedCylinder to in-progress fill entry type**
- **feat: show combined paired cylinder row with unlink in fills UI**
- **feat: validate fill gas type against both cylinders of a pair**
- **feat: expand paired cylinder fills into two records on submit**
- **feat: show paired cylinder indicator in cylinder list**
- **refactor: normalize paired cylinder in cylinder load hook**
- **refactor: use Heroicons LinkIcon for paired cylinder indicator**
